### PR TITLE
#25 ログアウト処理の実装を追加

### DIFF
--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -59,7 +59,7 @@ const handleLogin = async() => {
         <title>Tatoeba 例え話 ログインページ</title>
         <link rel='favicon.ico' />
       </Head>
-      <Header />
+      <Header password={password} email={email} />
       <LoginLayouts>
         <section className="
             bg-gray-100

--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -35,12 +35,11 @@ const handleLogin = async() => {
   // console.log(router.query);
 
     // ここで login 成功した場合に jwt トークンを保存するようにする。
-    const res = await fetch(process.env.NEXT_PUBLIC_BACKEND_URL + "/auth/login",
+    const res = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/auth/login`,
     {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': 'Bearer //トークン'
       },
       body: JSON.stringify({ password, email }),
     }

--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -8,20 +8,10 @@ import { setStorage } from '../src/lib/storage';
 
 export default function Login() {
   const router = useRouter()
-  const [loginToken, setLoginToken] = useState()
-  const [email, setEmail] = useState()
-  const [password, setPassword] = useState()
-  //バックエンドからきたレスポンスをもとにtokenを抽出
-  useEffect(() => {
-    const extractLoginToken = async() => {
-      //バックエンドのURLをかいてバックエンドからtokenを抽出
-      const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}`)
-      const data = await response.json()
+  // const [loginToken, setLoginToken] = useState()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
 
-      setLoginToken(data.token)
-    }
-    extractLoginToken()
-  },[])
 const handleChangeEmail = (e) => {
   setEmail(e.target.value)
 }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,17 +1,13 @@
-import React, { MouseEventHandler, useCallback, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import { useRouter } from 'next/router'
 import { deleteStorage } from '../../lib/storage';
 import Link from 'next/link';
 
 import { PencilAltIcon } from '@heroicons/react/outline'
 
-type LoginInfo = {
-  password : string | undefined;
-  email : string | undefined;
-}
-
-export const Header = (props: LoginInfo) => {
+export const Header = () => {
   const [isHover, setIsHover] = useState(true)
+  const router = useRouter()
   const handleToolTip = useCallback(
     () => {
       setIsHover(!isHover)
@@ -19,26 +15,12 @@ export const Header = (props: LoginInfo) => {
     [isHover],
   )
 
-  const handleClickLogout = async ():Promise<void> => {
-    const password = props.password
-    const email = props.email
-    // const router = useRouter()
-    //ログアウト処理
-    const res = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/auth/logout`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ password, email }),
-    }
-    )
-    const data = await res.json()
-
-    deleteStorage(data.token)
+  const handleClickLogout = async () => {
+    // ログアウト処理(フロント側でjwtを削除するだけで成立する)
+    deleteStorage('jwt')
 
     // トップページへ飛ぶ
-    // await router.push('/')
+    await router.push('/')
   }
 
   return (

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -10,7 +10,7 @@ type LoginInfo = {
   email : string | undefined;
 }
 
-export const Header = (props: LoginInfo ) => {
+export const Header = (props: LoginInfo) => {
   const [isHover, setIsHover] = useState(true)
   const handleToolTip = useCallback(
     () => {
@@ -19,12 +19,12 @@ export const Header = (props: LoginInfo ) => {
     [isHover],
   )
 
-  const handleClickLogout = async (props:LoginInfo):Promise<void> => {
+  const handleClickLogout = async ():Promise<void> => {
     const password = props.password
     const email = props.email
-    const router = useRouter()
+    // const router = useRouter()
     //ログアウト処理
-    const res = await fetch(process.env.NEXT_PUBLIC_BACKEND_URL + "/auth/login",
+    const res = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/auth/logout`,
     {
       method: 'POST',
       headers: {
@@ -38,7 +38,7 @@ export const Header = (props: LoginInfo ) => {
     deleteStorage(data.token)
 
     // トップページへ飛ぶ
-    await router.push('/')
+    // await router.push('/')
   }
 
   return (

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,19 +1,46 @@
-import React, { useCallback, useState } from 'react'
+import React, { MouseEventHandler, useCallback, useState } from 'react'
+import { useRouter } from 'next/router'
+import { deleteStorage } from '../../lib/storage';
+import Link from 'next/link';
+
 import { PencilAltIcon } from '@heroicons/react/outline'
-import Link from 'next/link'
 
-type Props = {
-
+type LoginInfo = {
+  password : string | undefined;
+  email : string | undefined;
 }
 
-export const Header = (props:Props) => {
-  const [isHover, setIsHover]= useState(true)
+export const Header = (props: LoginInfo ) => {
+  const [isHover, setIsHover] = useState(true)
   const handleToolTip = useCallback(
     () => {
       setIsHover(!isHover)
     },
     [isHover],
   )
+
+  const handleClickLogout = async (props:LoginInfo):Promise<void> => {
+    const password = props.password
+    const email = props.email
+    const router = useRouter()
+    //ログアウト処理
+    const res = await fetch(process.env.NEXT_PUBLIC_BACKEND_URL + "/auth/login",
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ password, email }),
+    }
+    )
+    const data = await res.json()
+
+    deleteStorage(data.token)
+
+    // トップページへ飛ぶ
+    await router.push('/')
+  }
+
   return (
     <header>
       <div className='
@@ -98,9 +125,11 @@ export const Header = (props:Props) => {
                 </Link>
               </li>
               <li className='py-2 text-sm text-gray-500 hover:bg-gray-100 hover:w-full'>
-                <Link href="/">
+                <button
+                onClick={handleClickLogout}
+                >
                   ログアウト
-                </Link>
+                </button>
               </li>
             </ul>
           </div>

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -16,3 +16,7 @@ export const setStorage = <T extends StorageKey>(
 ) => {
   localStorage.setItem(`${PREFIX}${key}`, value);
 };
+
+export const deleteStorage = <T extends StorageKey>(key: T) => {
+  return localStorage.removeItem(`${PREFIX}${key}`);
+};


### PR DESCRIPTION
# Issue URL

#25 

# このPRの対応範囲

- ログアウト処理の実装の追加

# 変更内容・変更理由

ログアウトは、フロント側でアクセストークンを削除するのみで成立するということがわかったため、フロントのみの実装とする。
