### PR TITLE
#36 ユーザー名が登録されていない場合は例えが投稿できないようにした

### DIFF
--- a/pages/DashBoard/index.tsx
+++ b/pages/DashBoard/index.tsx
@@ -62,7 +62,7 @@ const DashBoard = () => {
         <Header />
         <DashBoardLayouts>
           <ProfileLayouts>
-            <Profile userInfo={userInfo} />
+            <Profile />
           </ProfileLayouts>
         </DashBoardLayouts>
       </div>

--- a/pages/Register/RegisterWordChild/RegisterWordCreateBtn.tsx
+++ b/pages/Register/RegisterWordChild/RegisterWordCreateBtn.tsx
@@ -1,86 +1,92 @@
-import React from 'react'
+import React from 'react';
 // import { Modal } from '../../../src/components/Modal/Modal'
 import { useRouter } from 'next/router';
 import { useRecoilState } from 'recoil';
-import { WordsAtom } from '../../../src/components/utils/atoms/WordsAtom'
+import { WordsAtom } from '../../../src/components/utils/atoms/WordsAtom';
+import { UserNameAtom } from '../../../src/components/utils/atoms/UserNameAtom';
 
 export const RegisterWordCreateBtn = (props) => {
-  const { query_tId, title, shortParaphrase, description, creationTime} = props
-
-  const [words, setWords] = useRecoilState(WordsAtom)
+  const { query_tId, title, shortParaphrase, description, creationTime } =
+    props;
+  const [userName, setUserName] = useRecoilState(UserNameAtom);
+  const [words, setWords] = useRecoilState(WordsAtom);
   // const [show, setShow] = useState(false)
-  const router = useRouter()
+  const router = useRouter();
 
   // const openModal = useCallback(() => {
   //   setShow(true)
   // }, [])
 
-  function getUniqueId(){
-    return new Date().getTime().toString(36) + '-' + Math.random().toString(36)
+  function getUniqueId() {
+    return new Date().getTime().toString(36) + '-' + Math.random().toString(36);
   }
-  const tId = getUniqueId()
+  const tId = getUniqueId();
 
   const submitWords = () => {
-    if (title === "" || shortParaphrase === "" || description === "") {
-      alert("入力されていない箇所があります。")
-      return
+    if (title === '' || shortParaphrase === '' || description === '') {
+      alert('入力されていない箇所があります。');
+      return;
     }
-    {/* @ts-ignore */}
+    if (userName === '' || userName === null) {
+      alert('ユーザー名を登録して投稿してください。');
+      return;
+    }
+    {
+      /* @ts-ignore */
+    }
     // setShow(false)
 
-    if(!query_tId){
-      const firstAddWords =
-      [
+    if (!query_tId) {
+      const firstAddWords = [
         {
           tId,
           title,
           shortParaphrase,
           description,
-          creationTime
+          creationTime,
         },
         ...words,
-      ]
-      setWords(firstAddWords)
+      ];
+      setWords(firstAddWords);
 
       router.push({
-        pathname:'/DashBoard/UserTatoeList',
-      })
+        pathname: '/DashBoard/UserTatoeList',
+      });
     }
 
-    if(query_tId){
-
-      const newWords = words.map(item=> {
-        if(item.tId === query_tId){
+    if (query_tId) {
+      const newWords = words.map((item) => {
+        if (item.tId === query_tId) {
           return {
-              tId: item.tId,
-              title,
-              shortParaphrase,
-              description,
-              creationTime,
-            }
+            tId: item.tId,
+            title,
+            shortParaphrase,
+            description,
+            creationTime,
+          };
         } else {
-          return item
+          return item;
         }
-      })
-      setWords(newWords)
+      });
+      setWords(newWords);
 
-      words.map(item=> {
-        if(item.tId === query_tId){
+      words.map((item) => {
+        if (item.tId === query_tId) {
           router.push({
-            pathname:'/DashBoard/UserTatoeList',
-          })
+            pathname: '/DashBoard/UserTatoeList',
+          });
         }
-      })
+      });
     }
-  }
+  };
 
   return (
-    <div className="flex justify-end">
-    <button
-    // onClick={openModal}
-      onClick={submitWords}
-      type="submit"
-      className="
+    <div className='flex justify-end'>
+      <button
+        // onClick={openModal}
+        onClick={submitWords}
+        type='submit'
+        className='
       p-3
       w-[200px]
       rounded-full
@@ -88,11 +94,12 @@ export const RegisterWordCreateBtn = (props) => {
       text-gray-800
       text-lg
       hover:bg-opacity-90
-    ">
-      投稿する
-    </button>
-    {/* @ts-ignore */}
-    {/* <Modal show={show} setShow={setShow}/> */}
-  </div>
-  )
-}
+    '
+      >
+        投稿する
+      </button>
+      {/* @ts-ignore */}
+      {/* <Modal show={show} setShow={setShow}/> */}
+    </div>
+  );
+};

--- a/pages/Register/RegisterWordChild/RegisterWordCreateBtn.tsx
+++ b/pages/Register/RegisterWordChild/RegisterWordCreateBtn.tsx
@@ -8,7 +8,7 @@ import { UserNameAtom } from '../../../src/components/utils/atoms/UserNameAtom';
 export const RegisterWordCreateBtn = (props) => {
   const { query_tId, title, shortParaphrase, description, creationTime } =
     props;
-  const [userName, setUserName] = useRecoilState(UserNameAtom);
+  const [userName, setUserName] = useRecoilState<string | null>(UserNameAtom);
   const [words, setWords] = useRecoilState(WordsAtom);
   // const [show, setShow] = useState(false)
   const router = useRouter();

--- a/src/components/DashBoard/Profile.tsx
+++ b/src/components/DashBoard/Profile.tsx
@@ -10,10 +10,6 @@ import { useAuth } from '../hooks/useAuth';
 import { UserNameAtom } from '../utils/atoms/UserNameAtom';
 import { ProfileImage } from './ProfileImage';
 
-type User = {
-  userName: Required<string>;
-};
-
 export const Profile = () => {
   const { email } = useAuth();
 

--- a/src/components/DashBoard/Profile.tsx
+++ b/src/components/DashBoard/Profile.tsx
@@ -5,31 +5,26 @@ import React, {
   InputHTMLAttributes,
   useState,
 } from 'react';
-import { useRecoilState } from 'recoil';
+import { RecoilState, useRecoilState } from 'recoil';
 import { useAuth } from '../hooks/useAuth';
 import { UserNameAtom } from '../utils/atoms/UserNameAtom';
 import { ProfileImage } from './ProfileImage';
 
+type User = {
+  userName: Required<string>;
+};
+
 export const Profile = () => {
-  // バックエンドに対してアクセストークンを渡してユーザー一覧を要求
-  // 汎用性を考えると関数名がこれでいいかはわからない。
   const { email } = useAuth();
-  // console.log('useAuth', email);
 
-  // emailとuserNameをapiのデータから取り出して表示(passwordは表示しない)
-
-  // 新規会員登録した際の情報を更新する
-  const [userName, setUserName] = useRecoilState<string | null>(UserNameAtom);
+  // TODO 名前がない場合、投稿できないようにする => 投稿時必須
+  const [userName, setUserName] = useRecoilState<string>(UserNameAtom);
   const [isTyping, setIsTyping] = useState<boolean>(false);
   const [isFocus, setIsFocus] = useState<boolean>(true);
   const handleChangeUserName = (
     e: ChangeEvent<{ value: string }> | undefined
   ): void => {
     setUserName(e.target.value);
-    console.log('handleChangeUserName', userName);
-
-    // TODO 名前がない場合、投稿できないようにする => 投稿時必須
-    // TODO 現状、投稿時に投稿者名を入れていない仕様なので追加
   };
 
   const handleCompositionStart = () => {
@@ -61,7 +56,7 @@ export const Profile = () => {
       setUserName((prev): string => {
         return prev;
       });
-      console.log('email, userName', email, userName);
+
       setIsFocus(false);
       // users一覧にemailとuserNameを送る
       const res = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/users`, {
@@ -72,10 +67,6 @@ export const Profile = () => {
         body: JSON.stringify({ userName, email }),
       });
       await res.json();
-      // payloadにemail userName確認済み
-
-      // API側 localhost:3003/usersでUnAuthorized
-      // PrismaにuserNameカラムを作成する
     }
   };
 

--- a/src/components/DashBoard/Profile.tsx
+++ b/src/components/DashBoard/Profile.tsx
@@ -14,7 +14,7 @@ export const Profile = () => {
   const { email } = useAuth();
 
   // TODO 名前がない場合、投稿できないようにする => 投稿時必須
-  const [userName, setUserName] = useRecoilState<string>(UserNameAtom);
+  const [userName, setUserName] = useRecoilState<string | null>(UserNameAtom);
   const [isTyping, setIsTyping] = useState<boolean>(false);
   const [isFocus, setIsFocus] = useState<boolean>(true);
   const handleChangeUserName = (

--- a/src/components/utils/atoms/UserNameAtom.ts
+++ b/src/components/utils/atoms/UserNameAtom.ts
@@ -1,7 +1,7 @@
 import { atom } from 'recoil';
 import { recoilPersist } from 'recoil-persist';
 const { persistAtom } = recoilPersist();
-export const UserNameAtom = atom<string>({
+export const UserNameAtom = atom<string | null>({
   key: 'userName',
   default: null,
   effects_UNSTABLE: [persistAtom],

--- a/src/components/utils/atoms/UserNameAtom.ts
+++ b/src/components/utils/atoms/UserNameAtom.ts
@@ -1,7 +1,7 @@
 import { atom } from 'recoil';
 import { recoilPersist } from 'recoil-persist';
 const { persistAtom } = recoilPersist();
-export const UserNameAtom = atom<string | null>({
+export const UserNameAtom = atom<string>({
   key: 'userName',
   default: null,
   effects_UNSTABLE: [persistAtom],


### PR DESCRIPTION
# Issue URL

#36 

# このPRの対応範囲

- #36 のとおり、例え投稿時はユーザー名必須にした。

# 変更内容・変更理由

- 名無し状態で例えを投稿されると質の悪い投稿が増える可能性があるため、ユーザーに責任を持たせることを検討し、ユーザー名必須とした。
- 投稿時にユーザー名がないとアラートが出てくる仕組みを採用した。