### PR TITLE
#55 fetchのときjwtを直接呼び出しUnAuthorizedになっていたので、persistAccessTokenに変更

### DIFF
--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -3,7 +3,8 @@ import { LoginLayouts } from '../components/Layouts/LoginLayouts';
 import React, { useState } from 'react';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import { getStorage } from '../lib/storage';
+import { useRecoilValue } from 'recoil';
+import { LoginUserAtom } from '../components/utils/atoms/LoginUserAtom';
 
 const ResetPassword = () => {
   const router = useRouter();
@@ -11,7 +12,9 @@ const ResetPassword = () => {
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
 
-  // 現在のパスワードをユーザーに入力させて、API側で、その入力内容と今持っているDB側のデータが一致するかを確認する
+  // TODO usePersistAccessTokenの使い所確認
+  const persistAccessToken = useRecoilValue(LoginUserAtom);
+
   const handleChangeCurrentPassword = (
     e: React.ChangeEvent<HTMLInputElement> | undefined
   ) => {
@@ -48,12 +51,12 @@ const ResetPassword = () => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${getStorage('jwt')}`,
+          Authorization: `Bearer ${persistAccessToken}`,
         },
         body: JSON.stringify({ currentPassword, newPassword }),
       }
     );
-    const data = await res.json();
+    await res.json();
 
     //パスワード再設定完了ページへ飛ぶ
     await router.push('/complete_reset_password');
@@ -188,7 +191,7 @@ const ResetPassword = () => {
                   新パスワード確認
                 </p>
                 <input
-                  value={newPassword}
+                  value={confirmPassword}
                   className='
                             shadow-sm
                             outline-none


### PR DESCRIPTION
# Issue URL

#55 

# このPRの対応範囲

#55 の内容に加え、再設定ボタンを押して、実際にパスワード再設定が行われないことが判明したため、再設定ができるようにした。

# 変更理由・変更内容
- 新パスワード再確認=>` value={newPassword}`になってしまっていたので、`value={confirmPassword}`へ変更した。
- #55 の問題にあたり、さらに再設定したパスワードを持ってAPIに情報を送れないことに気づいたため、再設定のfetchの内容を変更した。
以前はBearerの中身は`${getStrage('jwt')}`でした。

変更内容は下記です。

```
const res = await fetch(
      `${process.env.NEXT_PUBLIC_BACKEND_URL}/auth/password_reset`,
      {
        method: 'POST',
        headers: {
          'Content-Type': 'application/json',
          Authorization: `Bearer ${persistAccessToken}`,
        },
        body: JSON.stringify({ currentPassword, newPassword }),
      }
    );
```