### PR TITLE
#63 キャンセルボタンを押下し例え一覧に遷移した際、元の作成日時が表示されるように修正

### DIFF
--- a/src/pages/Register/RegisterTatoeChild/CancelTatoeBtn.tsx
+++ b/src/pages/Register/RegisterTatoeChild/CancelTatoeBtn.tsx
@@ -4,8 +4,8 @@ import { useRecoilState } from 'recoil';
 import { TatoeAtom } from '../../../components/utils/atoms/TatoeAtom';
 import { Tatoe } from '../../../components/types/types';
 
-export const RegisterTatoeCancelBtn = (props: Tatoe) => {
-  const { query_tId, title, shortParaphrase, description, createdAt } = props;
+export const CancelTatoeBtn = (props: Tatoe) => {
+  const { query_tId } = props;
   const router = useRouter();
 
   const [tatoe, setTatoe] = useRecoilState<Tatoe[]>(TatoeAtom);
@@ -16,10 +16,11 @@ export const RegisterTatoeCancelBtn = (props: Tatoe) => {
         if (item.tId === query_tId) {
           return {
             tId: item.tId,
-            title,
-            shortParaphrase,
-            description,
-            createdAt,
+            title: item.title,
+            shortParaphrase: item.shortParaphrase,
+            description: item.description,
+            createdAt: item.createdAt,
+            updatedAt: item.updatedAt,
           };
         } else {
           return item;
@@ -30,7 +31,7 @@ export const RegisterTatoeCancelBtn = (props: Tatoe) => {
       tatoe.map((item) => {
         if (item.tId === query_tId) {
           router.push({
-            pathname: '/DashBoard',
+            pathname: '/DashBoard/UserTatoeList',
           });
         }
       });

--- a/src/pages/Register/RegisterTatoeParent.tsx
+++ b/src/pages/Register/RegisterTatoeParent.tsx
@@ -4,7 +4,7 @@ import { RegisterTatoeTitle } from './RegisterTatoeChild/RegisterTatoeTitle';
 import { RegisterTatoeShortParaphrase } from './RegisterTatoeChild/RegisterTatoeShortParaphrase';
 import { RegisterTatoeDescription } from './RegisterTatoeChild/RegisterTatoeDescription';
 
-import { RegisterTatoeCancelBtn } from './RegisterTatoeChild/RegisterTatoeCancelBtn';
+import { CancelTatoeBtn } from './RegisterTatoeChild/CancelTatoeBtn';
 import { useRouter } from 'next/router';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { TatoeAtom } from '../../components/utils/atoms/TatoeAtom';
@@ -109,6 +109,12 @@ export const RegisterTatoeParent = () => {
     });
   };
 
+  // tatoe.map((item: Tatoe) => {
+  //   if (item.tId === query_tId) {
+  //     console.log('@RegisterTatoeParent tatoe.createdAt *** ', tatoe.createdAt);
+  //   }
+  // });
+
   return (
     <div className='flex flex-col gap-6'>
       <RegisterTatoeTitle query={query} title={title} setTitle={setTitle} />
@@ -123,14 +129,7 @@ export const RegisterTatoeParent = () => {
         setDescription={setDescription}
       />
       <div className='mx-auto md:mx-0 md:justify-end pt-6 flex flex-col md:flex-row gap-6'>
-        <RegisterTatoeCancelBtn
-          query_tId={query.tId}
-          createdAt={createdAt}
-          updatedAt={updatedAt}
-          title={title}
-          shortParaphrase={shortParaphrase}
-          description={description}
-        />
+        <CancelTatoeBtn query_tId={query.tId} />
         <CreateTatoeBtn
           tatoe={tatoe}
           query_tId={query.tId}


### PR DESCRIPTION
# Issue URL

#63 

# このPRの対応範囲

- #63 の通り、キャンセルボタンを押下し例え一覧に遷移した際、元の作成日時が表示できるように実装する。
- こちらはフロント側のみの問題のため、API側では修正を行わない。