### PR TITLE
#57 キャンセルボタンのファイル置き場所が適切でなかったので、他のボタンと同じく、btnのdirectoryに移動。

### DIFF
--- a/src/components/btn/CancelTatoeBtn.tsx
+++ b/src/components/btn/CancelTatoeBtn.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { useRouter } from 'next/router';
 import { useRecoilState } from 'recoil';
-import { TatoeAtom } from '../../../components/utils/atoms/TatoeAtom';
-import { Tatoe } from '../../../components/types/types';
+import { TatoeAtom } from '../utils/atoms/TatoeAtom';
+import { Tatoe } from '../types/types';
 
 export const CancelTatoeBtn = (props: Tatoe) => {
   const { query_tId } = props;

--- a/src/pages/Register/RegisterTatoeParent.tsx
+++ b/src/pages/Register/RegisterTatoeParent.tsx
@@ -4,7 +4,7 @@ import { RegisterTatoeTitle } from './RegisterTatoeChild/RegisterTatoeTitle';
 import { RegisterTatoeShortParaphrase } from './RegisterTatoeChild/RegisterTatoeShortParaphrase';
 import { RegisterTatoeDescription } from './RegisterTatoeChild/RegisterTatoeDescription';
 
-import { CancelTatoeBtn } from './RegisterTatoeChild/CancelTatoeBtn';
+import { CancelTatoeBtn } from '../../components/btn/CancelTatoeBtn';
 import { useRouter } from 'next/router';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { TatoeAtom } from '../../components/utils/atoms/TatoeAtom';


### PR DESCRIPTION
# Issue URL

#57 

# このPRの対応範囲

- #57 の通りに置き場所の修正のみ実装すること。
- 機能などの修正はしていない。

# 変更理由・変更内容

- 元の場所URL
`pages/Register/RegisterTatoeChild/CancelTatoeBtn.tsx`

- 移動後
`src/components/btn/CancelTatoeBtn.tsx`
の配下に設置。