### PR TITLE
#66 例え一覧のUIを修正

### DIFF
--- a/src/components/DashBoard/TatoeList.tsx
+++ b/src/components/DashBoard/TatoeList.tsx
@@ -72,7 +72,7 @@ export const TatoeList = (): JSX.Element => {
                       className='
                                 flex
                                 text-gray-400
-                                text-xs
+                                text-xxs
                                 w-[124px]'
                     >
                       {item.createdAt}

--- a/src/components/DashBoard/TatoeListWrapper.tsx
+++ b/src/components/DashBoard/TatoeListWrapper.tsx
@@ -6,14 +6,21 @@ import { Layouts } from '../types/types';
 export const TatoeListWrapper: VFC<Layouts> = (props) => {
   return (
     <div>
-      <TatoeListAddNewTatoeBtn />
       <div
         className='
+        bg-inherit
         pt-6
         sm:pt-0
         md:pt-0
-        position'
+        min-w-[286px]
+        sm:min-w-[286px]
+        md:min-w-[364px]
+        lg:min-w-[726px]
+        position
+        relative
+        '
       >
+        <TatoeListAddNewTatoeBtn />
         <div>
           <h2
             className='

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -23,6 +23,7 @@ export const Header = () => {
     <header>
       <div
         className='
+        z-20
         pl-6
         pr-0
         sm:pl-6
@@ -38,7 +39,6 @@ export const Header = () => {
         border-b-2
         border-gray-800
         fixed
-        z-10
         position'
       >
         <Logo />

--- a/src/components/Layouts/DashBoard/DashBoardLayouts.tsx
+++ b/src/components/Layouts/DashBoard/DashBoardLayouts.tsx
@@ -6,7 +6,6 @@ export const DashBoardLayouts: VFC<Layouts> = (props) => {
   return (
     <main
       className='
-      bg-gray-100
       min-h-screen
       h-full
       md:px-18
@@ -18,28 +17,44 @@ export const DashBoardLayouts: VFC<Layouts> = (props) => {
         flex
         md:flex-row
         flex-col
+        position
+        relative
         '
       >
         <SideBarLayouts />
         <div
           className='
-          pt-0
-          sm:pt-[60px]
-          md:pt-[100px]
-          pb-14
-          max-w-[1200px]
-          md:min-w-[640px]
-          mx-auto
-          flex
-          lg:flex-row
-          flex-col
-          gap-y-8
-          sm:gap-x-8
-          lg:gap-x-8
-          position
+          absolute
+          top-16
+          sm:top-14
+          left-[4%]
+          right-[4%]
+          sm:left-[10%]
+          sm:right-[10%]
+          md:static
+          md:mx-auto
           '
         >
-          {props.children}
+          <div
+            className='
+            position
+            relative
+            pt-0
+            sm:pt-[60px]
+            md:pt-[100px]
+            pb-14
+            max-w-[1200px]
+            md:min-w-[640px]
+            flex
+            lg:flex-row
+            flex-col
+            gap-y-8
+            sm:gap-x-8
+            lg:gap-x-8
+            '
+          >
+            {props.children}
+          </div>
         </div>
       </div>
     </main>

--- a/src/components/Layouts/DashBoard/SideBarLayouts.tsx
+++ b/src/components/Layouts/DashBoard/SideBarLayouts.tsx
@@ -3,29 +3,42 @@ import React, { VFC } from 'react';
 import { WithoutPropsChildrenLayouts } from '../../types/types';
 import { SideBarMainContentsLayouts } from './SideBarMainContentsLayouts';
 
-export const SideBarLayouts: VFC<WithoutPropsChildrenLayouts> = (props) => {
+export const SideBarLayouts: VFC<WithoutPropsChildrenLayouts> = () => {
   return (
     <aside
       className='
-    bg-gray-900
-    sm:min-w-[64px]
-    sm:max-w-[64px]
-    max-w-full
-    flex
-    md:flex-col
-    flex-row
-    min-h-[96px]
-    md:h-full
-    '
+      position
+      relative
+      '
     >
       <nav
         className='
-      flex
-      md:flex-col
-      flex-row'
+        fixed
+        top-12
+        sm:top-12
+        left-0
+        z-10
+        bg-black
+        min-w-full
+        sm:min-w-[64px]
+        sm:max-w-[64px]
+        max-w-full
+        min-h-[48px]
+        md:h-full
+        flex
+        md:flex-col
+        flex-row
+        '
       >
-        <DashBoardMenuBtn />
-        <SideBarMainContentsLayouts />
+        <div
+          className='
+          flex
+          md:flex-col
+          flex-row'
+        >
+          <DashBoardMenuBtn />
+          <SideBarMainContentsLayouts />
+        </div>
       </nav>
     </aside>
   );

--- a/src/components/Layouts/DashBoard/TatoeListLayouts.tsx
+++ b/src/components/Layouts/DashBoard/TatoeListLayouts.tsx
@@ -5,7 +5,6 @@ export const TatoeListLayouts: VFC<Layouts> = (props) => {
   return (
     <div
       className='
-      bg-white
       lg:px-9
       px-4
       md:px-7
@@ -22,8 +21,7 @@ export const TatoeListLayouts: VFC<Layouts> = (props) => {
       w-[320px]
       sm:w-full
       lg:min-w-[800px]
-      position
-      relative
+      bg-white
       '
     >
       {props.children}

--- a/src/components/btn/TatoeListAddNewTatoeBtn.tsx
+++ b/src/components/btn/TatoeListAddNewTatoeBtn.tsx
@@ -7,11 +7,10 @@ export const TatoeListAddNewTatoeBtn = () => {
       className='
       absolute
       top-4
-      right-4
-      md:top-5
-      md:right-6
-      lg:top-6
-      lg:right-7
+      sm:-top-2
+      right-0
+      sm:right-0
+      md:-right-2
       '
     >
       <Link href='/Register'>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,6 +10,10 @@ module.exports = {
       'kakuGothic': ['"Zen Kaku Gothic New"'],
 
     },
+    fontSize: {
+      'extreme-s': '.5rem',
+      'xxs': '.625rem'
+    },
     screens: {
       sm: '480px',
       md: '768px',


### PR DESCRIPTION
# Issue URL

#66 

# このPRの対応範囲

- #66 のうち例え一覧のUIを修正した。
- それ以外はこのPRでは変更していない。

# 変更理由・変更内容

- 時間表示のサイズで元のxsサイズ(`.75rem=12px`) => xxsサイズ(`.625rem=10px`)を作成して適用した。
- サイドバーがスマホサイズ以上タブレットサイズ以下で上部に移動した時、固定になっていなかったので修正。
- 例え新規登録のボタンの位置のレスポンシブ時の修正。
- 他の要素を修正していくうち、例え一覧全体が中央に来ていないことがあったので、その位置の修正。
