### PR TITLE
#66 押し間違いを起きにくくするため目的別にボタンの出しわけができるように実装し、流行中の黒系デザインへ変更

### DIFF
--- a/src/components/btn/CancelTatoeBtn.tsx
+++ b/src/components/btn/CancelTatoeBtn.tsx
@@ -36,27 +36,37 @@ export const CancelTatoeBtn = (props: Tatoe) => {
         }
       });
     }
+    router.push({
+      pathname: '/DashBoard/UserTatoeList',
+    });
   };
 
   return (
-    <div className='flex justify-end'>
+    <div className='flex justify-end group'>
       <button
         onClick={handleClickCancel}
         type='submit'
         className='
-      p-3
-      w-[200px]
-      rounded-full
-      bg-white
-      text-gray-800
-      border-gray-800
-      border
-      text-lg
-      hover:bg-opacity-90
-    '
+        btn-m-white
+      '
       >
         キャンセル
       </button>
+      <div
+        className='
+      position
+      relative
+      '
+      >
+        <span
+          className='
+          absolute
+          material-symbols-outlined
+          btn-m-icon-black'
+        >
+          chevron_right
+        </span>
+      </div>
     </div>
   );
 };

--- a/src/components/btn/CreateTatoeBtn.tsx
+++ b/src/components/btn/CreateTatoeBtn.tsx
@@ -1,24 +1,45 @@
+import { useEffect, useState } from 'react';
 import { TatoeBtnProps } from '../types/types';
 
 export const CreateTatoeBtn = (props: TatoeBtnProps) => {
-  const { onClick } = props;
+  const { onClick, query_tId } = props;
+  const [isUpdate, setIsUpdate] = useState(false);
 
-  return (
-    <div className='flex justify-end'>
+  useEffect(() => {
+    const btnStyle = () => {
+      if (query_tId) {
+        setIsUpdate(true);
+      }
+    };
+    btnStyle();
+  }, [query_tId]);
+
+  return isUpdate ? null : (
+    <div className='flex justify-end group'>
       <button
         onClick={onClick}
         className='
-        p-3
-        w-[200px]
-        rounded-full
-        bg-dark_green
-        text-gray-800
-        text-lg
-        hover:bg-opacity-90
-      '
+        btn-m-color
+        '
       >
         投稿する
       </button>
+      <div
+        className='
+      position
+      relative
+      '
+      >
+        <span
+          className='
+          absolute
+          material-symbols-outlined
+          btn-m-icon-white
+          '
+        >
+          chevron_right
+        </span>
+      </div>
     </div>
   );
 };

--- a/src/components/btn/UpdateTatoeBtn.tsx
+++ b/src/components/btn/UpdateTatoeBtn.tsx
@@ -1,25 +1,46 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { TatoeBtnProps } from '../types/types';
 
 export const UpdateTatoeBtn = (props: TatoeBtnProps) => {
-  const { onClick } = props;
+  const { onClick, query_tId } = props;
 
-  return (
-    <div className='flex justify-end'>
+  const [isUpdate, setIsUpdate] = useState(false);
+
+  useEffect(() => {
+    const btnStyle = () => {
+      if (query_tId) {
+        setIsUpdate(true);
+      }
+    };
+    btnStyle();
+  }, [query_tId]);
+
+  return isUpdate ? (
+    <div className='flex justify-end group'>
       <button
         onClick={onClick}
         className='
-      p-3
-      w-[200px]
-      rounded-full
-      bg-dark_green
-      text-gray-800
-      text-lg
-      hover:bg-opacity-90
-    '
+        btn-m-color
+        '
       >
         更新する
       </button>
+      <div
+        className='
+      position
+      relative
+      '
+      >
+        <span
+          className='
+          absolute
+          material-symbols-outlined
+          btn-m-icon-white
+          '
+        >
+          chevron_right
+        </span>
+      </div>
     </div>
-  );
+  ) : null;
 };

--- a/src/pages/Register/RegisterTatoeChild/RegisterTatoeDescription.tsx
+++ b/src/pages/Register/RegisterTatoeChild/RegisterTatoeDescription.tsx
@@ -28,17 +28,12 @@ export const RegisterTatoeDescription = (props: DescriptionProps) => {
     >
       <label
         className='
-            text-gray-500
-            leading-tight
-            w-[300px]
-            pb-2
-            md:pb-2
-            lg:pb-0
-            select-none'
+        headline-s
+        '
       >
         詳しい説明
         <br />
-        <span className='text-xs text-gray-300'>400文字以内</span>
+        <span className='caption-s'>400文字以内</span>
       </label>
       <textarea
         value={description}
@@ -47,25 +42,7 @@ export const RegisterTatoeDescription = (props: DescriptionProps) => {
         placeholder='WEBサイトを「家」とすると、サーバーは「土地」に例えられます。'
         maxLength={400}
         rows={8}
-        className='
-            lg:max-w-[650px]
-            max-w-full
-            outline-none
-            focus:ring-2
-            focus:ring-green-400
-            focus:border-green-400
-            focus:placeholder-gray-300
-            px-3
-            pt-3
-            block
-            w-full
-            text-sm
-            md:text-sm
-            text-gray-700
-            border
-            border-gray-300
-            rounded-md
-            '
+        className='input-area'
       ></textarea>
     </div>
   );

--- a/src/pages/Register/RegisterTatoeChild/RegisterTatoeShortParaphrase.tsx
+++ b/src/pages/Register/RegisterTatoeChild/RegisterTatoeShortParaphrase.tsx
@@ -29,17 +29,11 @@ export const RegisterTatoeShortParaphrase = (props: ShortParaphraseProps) => {
     >
       <label
         className='
-            text-gray-500
-            leading-tight
-            w-[300px]
-            pb-2
-            md:pb-2
-            lg:pb-0
-            select-none'
+        headline-s'
       >
         短く例えると
         <br />
-        <span className='text-xs text-gray-300'>50文字以内</span>
+        <span className='caption-s'>50文字以内</span>
       </label>
       <input
         value={shortParaphrase}
@@ -47,24 +41,7 @@ export const RegisterTatoeShortParaphrase = (props: ShortParaphraseProps) => {
         name='short_paraphrase'
         placeholder='土地'
         type='text'
-        className='
-        lg:max-w-[650px]
-        max-w-full
-        outline-none
-        focus:ring-2
-        focus:ring-green-400
-        focus:border-green-400
-        focus:placeholder-gray-300
-        p-3
-        block
-        w-full
-        text-sm
-        md:text-sm
-        text-gray-700
-        border
-        border-gray-300
-        rounded-md
-        '
+        className='input-area'
       ></input>
     </div>
   );

--- a/src/pages/Register/RegisterTatoeChild/RegisterTatoeTitle.tsx
+++ b/src/pages/Register/RegisterTatoeChild/RegisterTatoeTitle.tsx
@@ -26,18 +26,12 @@ export const RegisterTatoeTitle = (props: TitleProps) => {
     >
       <label
         className='
-            text-gray-500
-            leading-tight
-            w-[300px]
-            pb-2
-            md:pb-2
-            lg:pb-0
-            select-none
-            '
+        headline-s
+        '
       >
         わかりにくい専門用語・文章
         <br />
-        <span className='text-xs text-gray-300'>50文字以内</span>
+        <span className='caption-s'>50文字以内</span>
       </label>
       <textarea
         value={title}
@@ -46,24 +40,7 @@ export const RegisterTatoeTitle = (props: TitleProps) => {
         rows={2}
         placeholder='サーバー'
         maxLength={50}
-        className='
-            lg:max-w-[650px]
-            max-w-full
-            outline-none
-            focus:ring-2
-            focus:ring-green-400
-            focus:border-green-400
-            focus:placeholder-gray-300
-            p-3
-            block
-            w-full
-            text-sm
-            md:text-sm
-            text-gray-700
-            border
-            border-gray-300
-            rounded-md
-        '
+        className='input-area'
       ></textarea>
     </div>
   );

--- a/src/pages/Register/RegisterTatoeHeadline.tsx
+++ b/src/pages/Register/RegisterTatoeHeadline.tsx
@@ -2,13 +2,11 @@ import React from 'react';
 
 export const RegisterTatoeHeadline = () => {
   return (
-    <div className='pb-8 sm:pb-12'>
+    <div className='pb-8 sm:pb-7'>
       <h1
         className='
-        text-2xl
-        text-gray-700
-        font-medium
-        select-none'
+        headline-m
+        '
       >
         例えの登録
       </h1>

--- a/src/pages/Register/RegisterTatoeParent.tsx
+++ b/src/pages/Register/RegisterTatoeParent.tsx
@@ -109,12 +109,6 @@ export const RegisterTatoeParent = () => {
     });
   };
 
-  // tatoe.map((item: Tatoe) => {
-  //   if (item.tId === query_tId) {
-  //     console.log('@RegisterTatoeParent tatoe.createdAt *** ', tatoe.createdAt);
-  //   }
-  // });
-
   return (
     <div className='flex flex-col gap-6'>
       <RegisterTatoeTitle query={query} title={title} setTitle={setTitle} />
@@ -128,7 +122,7 @@ export const RegisterTatoeParent = () => {
         description={description}
         setDescription={setDescription}
       />
-      <div className='mx-auto md:mx-0 md:justify-end pt-6 flex flex-col md:flex-row gap-6'>
+      <div className='mx-auto md:mx-0 md:justify-end pt-6 flex flex-col smd:flex-row gap-6'>
         <CancelTatoeBtn query_tId={query.tId} />
         <CreateTatoeBtn
           tatoe={tatoe}

--- a/src/pages/Register/index.tsx
+++ b/src/pages/Register/index.tsx
@@ -26,14 +26,7 @@ export default function Register() {
       >
         <div
           className='
-              lg:px-12
-              px-7
-              pt-10
-              pb-10
-              rounded-3xl
-              bg-white
-              border-[1px]
-              border-gray-800
+              frame-large
               mx-auto
               max-w-[1000px]
               '

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,6 @@
 import 'tailwindcss/tailwind.css';
 import '../../sass/main.scss';
+import '../../styles/globals.css';
 import React from 'react';
 import { RecoilRoot } from 'recoil';
 import { AppProps } from 'next/app';

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,32 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+
+export default function Document() {
+  return (
+    <Html>
+      <Head>
+        <link rel='preconnect' href='https://fonts.googleapis.com' />
+        <link
+          rel='preconnect'
+          href='https://fonts.gstatic.com'
+          crossOrigin='anonymous'
+        />
+        <link
+          href='https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100;500&display=swap'
+          rel='stylesheet'
+        />
+        <link
+          href='https://fonts.googleapis.com/css?family=Material+Icons|Material+Icons+Outlined|Material+Icons+Round|Material+Icons+Sharp|Material+Icons+Two+Tone'
+          rel='stylesheet'
+        ></link>
+        <link
+          rel='stylesheet'
+          href='https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200'
+        />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -23,3 +23,50 @@
     box-sizing: border-box;
   }
 }
+.material-symbols-outlined {
+  font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 48;
+}
+
+.headline-m {
+  @apply text-2xl text-black font-medium select-none;
+}
+
+.headline-s {
+  @apply text-sm text-gray-500 leading-tight w-[300px] pb-1 md:pb-1 lg:pb-0 select-none;
+}
+
+.caption-s {
+  @apply text-xxs text-gray-300;
+}
+
+.frame-large {
+  @apply lg:px-12 px-7 pt-10 pb-10 rounded-3xl bg-white border border-black;
+}
+
+.frame-middle-shadow {
+}
+
+.input-area {
+  @apply p-3 block w-full text-sm md:text-sm text-gray-700 rounded-md border-black border lg:max-w-[650px] max-w-full outline-none focus:ring-2 focus:ring-green-400 focus:border-green-400 focus:placeholder-gray-300;
+}
+
+.btn-m-white {
+  @apply p-4 w-[200px] rounded-full bg-white text-gray-800 border-gray-800 border
+text-xs transition-all group-hover:opacity-60;
+}
+
+.btn-m-color {
+  @apply p-4 w-[200px] rounded-full text-white text-xs transition-all bg-black group-hover:bg-opacity-80;
+}
+
+.btn-m-icon-base {
+  @apply top-[18px] right-1 text-base transition-all group-hover:opacity-80;
+}
+
+.btn-m-icon-white {
+  @apply btn-m-icon-base text-white;
+}
+
+.btn-m-icon-black {
+  @apply btn-m-icon-base text-black;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,12 +10,10 @@ module.exports = {
       'kakuGothic': ['"Zen Kaku Gothic New"'],
 
     },
-    fontSize: {
-      'extreme-s': '.5rem',
-      'xxs': '.625rem'
-    },
     screens: {
+      xs: '376px',
       sm: '480px',
+      smd: '600px',
       md: '768px',
       lg: '976px',
       xl: '1440px',
@@ -33,6 +31,13 @@ module.exports = {
       },
       fontFamily: {
         'kakuGothic': ['"Zen Kaku Gothic New"'],
+      },
+      fontSize: {
+        'extreme-s': ['.5rem', null],
+        'xxs': ['.625rem', null],
+        'xs': ['.75rem', null],
+        'sm': ['.875rem', null],
+        'base': ['1rem', null]
       },
       animation: {
         'expand-border': 'expand-border 2s ease infinite'


### PR DESCRIPTION
# Issue URL

#66 

# このPRの対応範囲

- #66 のうち、例え登録の画面でユーザーが迷わないようなボタンのUIに修正する。
- 例え一覧のページやヘッダーについては触っていない。

# 変更内容・変更理由
- 以前のデザインだと、キャンセル・投稿する・更新するの3つが同時に出ており、その時の目的によってどのボタンを押してよいかがわかりにくい。
そのため、目的に合わせて投稿するボタンまたは更新するボタンを出しわけすることで、ユーザビリティを良くした。
ボタンがいくつもあると迷いやすく、2択状態にあった方が判断する際のストレスが少ないことも考えられる。
- 同じページ内のその他の要素も現在流行っている黒系を取り入れたデザインへ変更した。