### PR TITLE
#30 プロフィールでユーザーがアバター登録ができるようにすること

### DIFF
--- a/src/components/DashBoard/Profile.tsx
+++ b/src/components/DashBoard/Profile.tsx
@@ -80,10 +80,6 @@ export const Profile = () => {
   };
   // const handleOnChangeAvatar = () => {};
 
-  // TODO 動的にsrcURLを変更する
-  // ユーザーが画像変更したらそのsrcがここに入る
-  // => ユーザーは画像をAPI側へ投げているので、そのAPIの画像データが返ってきたらそのパスを取得？
-
   if (isLoading) {
     return (
       <div>

--- a/src/components/DashBoard/Profile.tsx
+++ b/src/components/DashBoard/Profile.tsx
@@ -16,7 +16,8 @@ import { ProfileImage } from './ProfileImage';
 export const Profile = () => {
   const { userId } = useAuth();
   const [userName, setUserName] = useState<string | undefined>('');
-  const { user, updateUser, isLoading, error } = useUserInfo(userId);
+  const { user, updateUser, isLoading, error, avatarImagePath } =
+    useUserInfo(userId);
 
   const [isTyping, setIsTyping] = useState<boolean>(false);
   const [isFocus, setIsFocus] = useState<boolean>(true);
@@ -82,7 +83,6 @@ export const Profile = () => {
   // TODO 動的にsrcURLを変更する
   // ユーザーが画像変更したらそのsrcがここに入る
   // => ユーザーは画像をAPI側へ投げているので、そのAPIの画像データが返ってきたらそのパスを取得？
-  const avatarImagePath = '';
 
   if (isLoading) {
     return (

--- a/src/components/DashBoard/Profile.tsx
+++ b/src/components/DashBoard/Profile.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import React, {
   ChangeEvent,
+  ChangeEventHandler,
   DetailedHTMLProps,
   InputHTMLAttributes,
   useEffect,
@@ -14,7 +15,7 @@ import { ProfileImage } from './ProfileImage';
 
 export const Profile = () => {
   const { userId } = useAuth();
-  const [userName, setUserName] = useState<string>('');
+  const [userName, setUserName] = useState<string | undefined>('');
   const { user, updateUser, isLoading, error } = useUserInfo(userId);
 
   const [isTyping, setIsTyping] = useState<boolean>(false);
@@ -23,6 +24,9 @@ export const Profile = () => {
   const handleChangeUserName = (
     e: ChangeEvent<{ value: string }> | undefined
   ): void => {
+    if (!e) {
+      return;
+    }
     setUserName(e.target.value);
   };
 
@@ -53,12 +57,14 @@ export const Profile = () => {
     // Promise型解決できないので一旦any
     // @ts-ignore shiftKeyの型が解決できないので一旦無視
     if (event.key === 'Enter' && !isTyping && !event.shiftKey) {
-      setUserName((prev): string => {
+      setUserName((prev): string | undefined => {
         return prev;
       });
 
       setIsFocus(false);
       await updateUser({ userName });
+      console.log('===== @profile userName ===== ', userName);
+      console.log('===== @profile user =====', user);
     }
   };
 
@@ -72,6 +78,11 @@ export const Profile = () => {
     updateUserProfileImage(file);
   };
   // const handleOnChangeAvatar = () => {};
+
+  // TODO 動的にsrcURLを変更する
+  // ユーザーが画像変更したらそのsrcがここに入る
+  // => ユーザーは画像をAPI側へ投げているので、そのAPIの画像データが返ってきたらそのパスを取得？
+  const avatarImagePath = '';
 
   if (isLoading) {
     return (
@@ -119,6 +130,7 @@ export const Profile = () => {
             <ProfileImage
               onSubmit={handleOnSubmit}
               // onChange={handleOnChangeAvatar}
+              avatarImagePath={avatarImagePath}
             />
           ) : (
             <Image
@@ -148,7 +160,7 @@ export const Profile = () => {
                 '
             >
               <input
-                defaultValue={user}
+                defaultValue={user as unknown as string | undefined}
                 value={userName}
                 onChange={handleChangeUserName}
                 onFocus={handleOnFocus}

--- a/src/components/DashBoard/Profile.tsx
+++ b/src/components/DashBoard/Profile.tsx
@@ -1,8 +1,6 @@
 import Link from 'next/link';
-import Image from 'next/image';
 import React, {
   ChangeEvent,
-  ChangeEventHandler,
   DetailedHTMLProps,
   InputHTMLAttributes,
   useEffect,
@@ -16,14 +14,8 @@ import { ProfileImage } from './ProfileImage';
 export const Profile = () => {
   const { userId } = useAuth();
   const [userName, setUserName] = useState<string | undefined>('');
-  const {
-    user,
-    updateUser,
-    isLoading,
-    error,
-    avatarImagePath,
-    getUserProfileImage,
-  } = useUserInfo(userId);
+  const { user, updateUser, isLoading, error, updateUserProfileImage } =
+    useUserInfo(userId);
 
   const [isTyping, setIsTyping] = useState<boolean>(false);
   const [isFocus, setIsFocus] = useState<boolean>(true);
@@ -47,7 +39,6 @@ export const Profile = () => {
   const handleOnFocus = () => {
     setIsFocus(true);
   };
-  const { updateUserProfileImage } = useUserInfo(userId);
 
   const focusCSS =
     'outline-dark_green focus:outline-offset-2 focus:outline focus:outline-4';
@@ -84,7 +75,6 @@ export const Profile = () => {
   const handleOnSubmit = (file: File) => {
     updateUserProfileImage(file);
   };
-  // const handleOnChangeAvatar = () => {};
 
   if (isLoading) {
     return (
@@ -128,32 +118,7 @@ export const Profile = () => {
             relative
             '
         >
-          {/* ここはあとで消す */}
-          <button
-            type='button'
-            onClick={getUserProfileImage}
-            className='bg-red-600 px-3 py-2 rounded-full text-xxs'
-          >
-            GET IMAGE
-          </button>
-          {/* ここからほんもの */}
-          {userId ? (
-            <ProfileImage
-              onSubmit={handleOnSubmit}
-              // onChange={handleOnChangeAvatar}
-              avatarImagePath={avatarImagePath}
-            />
-          ) : (
-            <Image
-              src='/images/women3.jpg'
-              alt='ユーザーの画像'
-              width={200}
-              height={200}
-              className='
-                rounded-full
-                object-cover'
-            />
-          )}
+          <ProfileImage onSubmit={handleOnSubmit} userId={userId} />
           <div
             className='
             flex

--- a/src/components/DashBoard/Profile.tsx
+++ b/src/components/DashBoard/Profile.tsx
@@ -16,8 +16,14 @@ import { ProfileImage } from './ProfileImage';
 export const Profile = () => {
   const { userId } = useAuth();
   const [userName, setUserName] = useState<string | undefined>('');
-  const { user, updateUser, isLoading, error, avatarImagePath } =
-    useUserInfo(userId);
+  const {
+    user,
+    updateUser,
+    isLoading,
+    error,
+    avatarImagePath,
+    getUserProfileImage,
+  } = useUserInfo(userId);
 
   const [isTyping, setIsTyping] = useState<boolean>(false);
   const [isFocus, setIsFocus] = useState<boolean>(true);
@@ -122,6 +128,15 @@ export const Profile = () => {
             relative
             '
         >
+          {/* ここはあとで消す */}
+          <button
+            type='button'
+            onClick={getUserProfileImage}
+            className='bg-red-600 px-3 py-2 rounded-full text-xxs'
+          >
+            GET IMAGE
+          </button>
+          {/* ここからほんもの */}
           {userId ? (
             <ProfileImage
               onSubmit={handleOnSubmit}

--- a/src/components/DashBoard/Profile.tsx
+++ b/src/components/DashBoard/Profile.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import Image from 'next/image';
 import React, {
   ChangeEvent,
   DetailedHTMLProps,
@@ -82,6 +83,10 @@ export const Profile = () => {
     );
   }
 
+  //　TODO 画像登録
+  const handleOnSubmit = () => {};
+  const handleOnChangeAvatar = () => {};
+
   return (
     <div className='group'>
       <div
@@ -108,7 +113,22 @@ export const Profile = () => {
             relative
             '
         >
-          <ProfileImage />
+          {userId ? (
+            <ProfileImage
+              onSubmit={handleOnSubmit}
+              onChange={handleOnChangeAvatar}
+            />
+          ) : (
+            <Image
+              src='/images/women3.jpg'
+              alt='ユーザーの画像'
+              width={200}
+              height={200}
+              className='
+                rounded-full
+                object-cover'
+            />
+          )}
           <div
             className='
             flex

--- a/src/components/DashBoard/Profile.tsx
+++ b/src/components/DashBoard/Profile.tsx
@@ -36,6 +36,7 @@ export const Profile = () => {
   const handleOnFocus = () => {
     setIsFocus(true);
   };
+  const { updateUserProfileImage } = useUserInfo(userId);
 
   const focusCSS =
     'outline-dark_green focus:outline-offset-2 focus:outline focus:outline-4';
@@ -67,6 +68,11 @@ export const Profile = () => {
     }
   }, [user]);
 
+  const handleOnSubmit = (file: File) => {
+    updateUserProfileImage(file);
+  };
+  // const handleOnChangeAvatar = () => {};
+
   if (isLoading) {
     return (
       <div>
@@ -82,10 +88,6 @@ export const Profile = () => {
       </div>
     );
   }
-
-  //　TODO 画像登録
-  const handleOnSubmit = () => {};
-  const handleOnChangeAvatar = () => {};
 
   return (
     <div className='group'>
@@ -116,7 +118,7 @@ export const Profile = () => {
           {userId ? (
             <ProfileImage
               onSubmit={handleOnSubmit}
-              onChange={handleOnChangeAvatar}
+              // onChange={handleOnChangeAvatar}
             />
           ) : (
             <Image

--- a/src/components/DashBoard/ProfileImage.tsx
+++ b/src/components/DashBoard/ProfileImage.tsx
@@ -4,7 +4,6 @@ import React, {
   MouseEventHandler,
   ChangeEventHandler,
   useState,
-  ReactEventHandler,
 } from 'react';
 
 type SubmitImage = {
@@ -18,8 +17,7 @@ export const ProfileImage = ({
   avatarImagePath,
 }: SubmitImage) => {
   const ref = useRef<HTMLInputElement>(null);
-  const [avatar, setAvatar] = useState('');
-
+  const [isAvatar, setIsAvatar] = useState<boolean>(false);
   const handleClickImageButton: MouseEventHandler<HTMLButtonElement> = (e) => {
     e.preventDefault();
     if (!ref.current) {
@@ -34,12 +32,15 @@ export const ProfileImage = ({
     }
     const file = e.target.files[0];
     onSubmit(file);
+    setIsAvatar(true);
   };
 
   const handleOnLoadImage: ChangeEventHandler<HTMLImageElement> = (e) => {
     //　メモリの開放
     URL.revokeObjectURL(e.target.src);
   };
+  // API側の画像は取得できていないがblobは生成されてここにも通っている
+  console.log('ProfileImage **** avatarImagePath', avatarImagePath);
 
   // TODO モーダルをかませる可能性あり モーダル使用時はformを使うこと
   return (
@@ -53,7 +54,7 @@ export const ProfileImage = ({
         {/* <form onSubmit={onSubmit}> */}
         <input type='file' onChange={handleChangeFile} hidden ref={ref} />
         <button type='button' onClick={handleClickImageButton}>
-          {avatar ? (
+          {isAvatar ? (
             <Image
               src={avatarImagePath}
               onLoad={handleOnLoadImage}

--- a/src/components/DashBoard/ProfileImage.tsx
+++ b/src/components/DashBoard/ProfileImage.tsx
@@ -1,29 +1,35 @@
-import Image from 'next/image'
-import React from 'react'
+import Image from 'next/image';
+import React from 'react';
 
-export const ProfileImage = () => {
+type SubmitAvatar = {
+  onSubmit: () => void;
+  onChange: () => void;
+};
+
+export const ProfileImage = ({ onSubmit, onChange }: SubmitAvatar) => {
   return (
     <div>
-        <div
-            className='
+      <div
+        className='
             h-[100px]
             w-[100px]
             '
-            >
-              {/* 画像変更できるようにする */}
-              <button
-              >
-                <Image
-                  src="/images/women3.jpg"
-                  alt="ユーザーの画像"
-                  width={200}
-                  height={200}
-                  className="
+      >
+        <form onSubmit={onSubmit}>
+          <input type='file' onChange={onChange} />
+          <button type='submit'>
+            <Image
+              src='/images/women3.jpg'
+              alt='ユーザーの画像'
+              width={200}
+              height={200}
+              className='
                   rounded-full
-                  object-cover"
-                />
-              </button>
-        </div>
+                  object-cover'
+            />
+          </button>
+        </form>
+      </div>
     </div>
-  )
-}
+  );
+};

--- a/src/components/DashBoard/ProfileImage.tsx
+++ b/src/components/DashBoard/ProfileImage.tsx
@@ -1,23 +1,15 @@
-import Image from 'next/image';
-import React, {
-  useRef,
-  MouseEventHandler,
-  ChangeEventHandler,
-  useState,
-} from 'react';
+import React, { useRef, MouseEventHandler, ChangeEventHandler } from 'react';
+import { useRecoilValue } from 'recoil';
+import { ProfileImageAtom } from '../utils/atoms/ProfileImageAtom';
 
-type SubmitImage = {
+type ProfileImageProps = {
   onSubmit: (file: File) => void;
-  // onChange: (file: File) => void;
-  avatarImagePath: string | undefined;
+  userId: string;
 };
 
-export const ProfileImage = ({
-  onSubmit /*onChange*/,
-  avatarImagePath,
-}: SubmitImage) => {
+export const ProfileImage = ({ onSubmit, userId }: ProfileImageProps) => {
   const ref = useRef<HTMLInputElement>(null);
-  const [isAvatar, setIsAvatar] = useState<boolean>(false);
+  const profileImage = useRecoilValue(ProfileImageAtom);
   const handleClickImageButton: MouseEventHandler<HTMLButtonElement> = (e) => {
     e.preventDefault();
     if (!ref.current) {
@@ -32,15 +24,7 @@ export const ProfileImage = ({
     }
     const file = e.target.files[0];
     onSubmit(file);
-    setIsAvatar(true);
   };
-
-  const handleOnLoadImage: ChangeEventHandler<HTMLImageElement> = (e) => {
-    //　メモリの開放
-    URL.revokeObjectURL(e.target.src);
-  };
-  // API側の画像は取得できていないがblobは生成されてここにも通っている
-  console.log('ProfileImage **** avatarImagePath', avatarImagePath);
 
   // TODO モーダルをかませる可能性あり モーダル使用時はformを使うこと
   return (
@@ -54,28 +38,15 @@ export const ProfileImage = ({
         {/* <form onSubmit={onSubmit}> */}
         <input type='file' onChange={handleChangeFile} hidden ref={ref} />
         <button type='button' onClick={handleClickImageButton}>
-          {isAvatar ? (
-            <Image
-              src={avatarImagePath}
-              onLoad={handleOnLoadImage}
-              alt='ユーザーの画像'
-              width={200}
-              height={200}
-              className='
+          <img
+            src={`${process.env.NEXT_PUBLIC_BACKEND_URL}/users/${userId}/profile_image?t=${profileImage}`}
+            alt='ユーザーの画像'
+            width={200}
+            height={200}
+            className='
                   rounded-full
                   object-cover'
-            />
-          ) : (
-            <Image
-              src='/images/women3.jpg'
-              alt='ユーザーの画像'
-              width={200}
-              height={200}
-              className='
-                rounded-full
-                object-cover'
-            />
-          )}
+          />
         </button>
         {/* </form> */}
       </div>

--- a/src/components/DashBoard/ProfileImage.tsx
+++ b/src/components/DashBoard/ProfileImage.tsx
@@ -1,12 +1,29 @@
 import Image from 'next/image';
-import React from 'react';
+import React, { useRef, MouseEventHandler, ChangeEventHandler } from 'react';
 
-type SubmitAvatar = {
-  onSubmit: () => void;
-  onChange: () => void;
+type SubmitImage = {
+  onSubmit: (file: File) => void;
+  // onChange: (file: File) => void;
 };
 
-export const ProfileImage = ({ onSubmit, onChange }: SubmitAvatar) => {
+export const ProfileImage = ({ onSubmit /*onChange*/ }: SubmitImage) => {
+  const ref = useRef<HTMLInputElement>(null);
+
+  const handleClickImageButton: MouseEventHandler<HTMLButtonElement> = (e) => {
+    e.preventDefault();
+    ref.current.click();
+  };
+
+  const handleChangeFile: ChangeEventHandler<HTMLInputElement> = (e) => {
+    const file = e.target.files[0];
+
+    if (!file) {
+      return;
+    }
+    onSubmit(file);
+  };
+
+  // TODO モーダルをかませる可能性あり モーダル使用時はformを使うこと
   return (
     <div>
       <div
@@ -15,20 +32,20 @@ export const ProfileImage = ({ onSubmit, onChange }: SubmitAvatar) => {
             w-[100px]
             '
       >
-        <form onSubmit={onSubmit}>
-          <input type='file' onChange={onChange} />
-          <button type='submit'>
-            <Image
-              src='/images/women3.jpg'
-              alt='ユーザーの画像'
-              width={200}
-              height={200}
-              className='
+        {/* <form onSubmit={onSubmit}> */}
+        <input type='file' onChange={handleChangeFile} hidden ref={ref} />
+        <button type='button' onClick={handleClickImageButton}>
+          <Image
+            src='/images/women3.jpg'
+            alt='ユーザーの画像'
+            width={200}
+            height={200}
+            className='
                   rounded-full
                   object-cover'
-            />
-          </button>
-        </form>
+          />
+        </button>
+        {/* </form> */}
       </div>
     </div>
   );

--- a/src/components/DashBoard/ProfileImage.tsx
+++ b/src/components/DashBoard/ProfileImage.tsx
@@ -1,26 +1,44 @@
 import Image from 'next/image';
-import React, { useRef, MouseEventHandler, ChangeEventHandler } from 'react';
+import React, {
+  useRef,
+  MouseEventHandler,
+  ChangeEventHandler,
+  useState,
+  ReactEventHandler,
+} from 'react';
 
 type SubmitImage = {
   onSubmit: (file: File) => void;
   // onChange: (file: File) => void;
+  avatarImagePath: string | undefined;
 };
 
-export const ProfileImage = ({ onSubmit /*onChange*/ }: SubmitImage) => {
+export const ProfileImage = ({
+  onSubmit /*onChange*/,
+  avatarImagePath,
+}: SubmitImage) => {
   const ref = useRef<HTMLInputElement>(null);
+  const [avatar, setAvatar] = useState('');
 
   const handleClickImageButton: MouseEventHandler<HTMLButtonElement> = (e) => {
     e.preventDefault();
+    if (!ref.current) {
+      return;
+    }
     ref.current.click();
   };
 
   const handleChangeFile: ChangeEventHandler<HTMLInputElement> = (e) => {
-    const file = e.target.files[0];
-
-    if (!file) {
+    if (!e.target.files) {
       return;
     }
+    const file = e.target.files[0];
     onSubmit(file);
+  };
+
+  const handleOnLoadImage: ChangeEventHandler<HTMLImageElement> = (e) => {
+    //　メモリの開放
+    URL.revokeObjectURL(e.target.src);
   };
 
   // TODO モーダルをかませる可能性あり モーダル使用時はformを使うこと
@@ -35,15 +53,28 @@ export const ProfileImage = ({ onSubmit /*onChange*/ }: SubmitImage) => {
         {/* <form onSubmit={onSubmit}> */}
         <input type='file' onChange={handleChangeFile} hidden ref={ref} />
         <button type='button' onClick={handleClickImageButton}>
-          <Image
-            src='/images/women3.jpg'
-            alt='ユーザーの画像'
-            width={200}
-            height={200}
-            className='
+          {avatar ? (
+            <Image
+              src={avatarImagePath}
+              onLoad={handleOnLoadImage}
+              alt='ユーザーの画像'
+              width={200}
+              height={200}
+              className='
                   rounded-full
                   object-cover'
-          />
+            />
+          ) : (
+            <Image
+              src='/images/women3.jpg'
+              alt='ユーザーの画像'
+              width={200}
+              height={200}
+              className='
+                rounded-full
+                object-cover'
+            />
+          )}
         </button>
         {/* </form> */}
       </div>

--- a/src/components/hooks/useUserInfo.tsx
+++ b/src/components/hooks/useUserInfo.tsx
@@ -53,5 +53,22 @@ export const useUserInfo = (userId: string | null) => {
     await res.json();
     setUser(data);
   };
-  return { user, updateUser, isLoading, error };
+
+  const updateUserProfileImage = async (file: File) => {
+    const formData = new FormData();
+    formData.append('image', file);
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_BACKEND_URL}/users/${userId}/profile_image`,
+      {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${persistAccessToken}`,
+        },
+        body: formData,
+      }
+    );
+    // const { data } = await res.json();
+    // setUser(data);
+  };
+  return { user, updateUser, isLoading, error, updateUserProfileImage };
 };

--- a/src/components/hooks/useUserInfo.tsx
+++ b/src/components/hooks/useUserInfo.tsx
@@ -71,19 +71,22 @@ export const useUserInfo = (userId: string | null) => {
       {
         method: 'GET',
         headers: {
-          Authorization: `Bearer ${persistAccessToken}`,
+          'Content-Type': 'application/json',
         },
       }
     )
       .then((res) => {
         if (!res.ok) {
-          throw '画像取得エラー';
+          throw '画像取得エラーがおきました。';
         }
         return res.blob();
       })
       .then((blobData) => {
-        // TODO Profile avatarのsrcに変数を入れる
+        // TODO Profile avatarの<img src>に変数を入れる
+        // 直接 GCS URLをsrc指定だと使い切りタイプ?のようなので
+        // 一意のURLを作成して変数化、ただし同じURL使って再度画像を取得することはできない
 
+        // 赤いボタンを押すとblobは生成されてる
         const newAvatarImagePath = URL.createObjectURL(blobData);
         console.log(newAvatarImagePath);
         setAvatarImagePath(newAvatarImagePath);
@@ -104,6 +107,7 @@ export const useUserInfo = (userId: string | null) => {
       }
     );
     // TODO APIでGCS登録されたデータが返ってきてそれをフロントのアバターに登録？
+    // Blob: {size:}が返ってきた
     const data = await res.blob();
     console.log(data);
   };

--- a/src/components/hooks/useUserInfo.tsx
+++ b/src/components/hooks/useUserInfo.tsx
@@ -1,16 +1,19 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
+import { User } from '../types/types';
 import { LoginUserAtom } from '../utils/atoms/LoginUserAtom';
 
 export const useUserInfo = (userId: string | null) => {
-  const [user, setUser] = useState(null);
+  const [user, setUser] = useState<User | undefined>(undefined);
   const persistAccessToken = useRecoilValue(LoginUserAtom);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
+  console.log('useUserInfo after ### useState ### user', user);
 
   useEffect(() => {
     setIsLoading(true);
     setError(null);
+    // 自分のプロフィール(名前など)を取得
     const main = async () => {
       const res = await fetch(
         `${process.env.NEXT_PUBLIC_BACKEND_URL}/users/${userId}`,
@@ -28,6 +31,7 @@ export const useUserInfo = (userId: string | null) => {
       }
       setUser(data);
     };
+
     main()
       .catch(() => {
         setError('データの取得に失敗しました。');
@@ -50,8 +54,39 @@ export const useUserInfo = (userId: string | null) => {
         body: JSON.stringify({ userName }),
       }
     );
-    await res.json();
-    setUser(data);
+
+    const { updatedData } = await res.json();
+    setUser(updatedData);
+    console.log('updatedData', updatedData); // 値とれてる
+    console.log('!!!! user', user); // 1週遅れ
+    console.log('user userName', user?.userName); // 1週遅れ
+  };
+
+  const getUserProfileImage = async (file: File) => {
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_BACKEND_URL}/users/${userId}/profile_image`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${persistAccessToken}`,
+        },
+      }
+    )
+      .then((res) => {
+        if (!res.ok) {
+          throw '画像取得エラー';
+        }
+        return res.blob();
+      })
+      .then((blobData) => {
+        // TODO Profile avatarのsrcに変数を入れる
+
+        const avatarImagePath = URL.createObjectURL(blobData);
+        console.log(avatarImagePath);
+
+        // これだとブロック外では使えない
+        return avatarImagePath;
+      });
   };
 
   const updateUserProfileImage = async (file: File) => {
@@ -67,8 +102,16 @@ export const useUserInfo = (userId: string | null) => {
         body: formData,
       }
     );
-    // const { data } = await res.json();
-    // setUser(data);
+    // TODO APIでGCS登録されたデータが返ってきてそれをフロントのアバターに登録？
+    const data = await res.blob();
+    console.log(data);
   };
-  return { user, updateUser, isLoading, error, updateUserProfileImage };
+  return {
+    user,
+    updateUser,
+    isLoading,
+    error,
+    updateUserProfileImage,
+    getUserProfileImage,
+  };
 };

--- a/src/components/hooks/useUserInfo.tsx
+++ b/src/components/hooks/useUserInfo.tsx
@@ -1,15 +1,16 @@
 import { useEffect, useState } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { User } from '../types/types';
 import { LoginUserAtom } from '../utils/atoms/LoginUserAtom';
+import { ProfileImageAtom } from '../utils/atoms/ProfileImageAtom';
 
 export const useUserInfo = (userId: string | null) => {
   const [user, setUser] = useState<User | undefined>(undefined);
   const persistAccessToken = useRecoilValue(LoginUserAtom);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
-  console.log('useUserInfo after ### useState ### user', user);
-  const [avatarImagePath, setAvatarImagePath] = useState('');
+  // console.log('useUserInfo after ### useState ### user', user);
+  const setProfileImage = useSetRecoilState(ProfileImageAtom);
 
   useEffect(() => {
     setIsLoading(true);
@@ -63,36 +64,6 @@ export const useUserInfo = (userId: string | null) => {
     console.log('user userName', user?.userName); // 1週遅れ
   };
 
-  // これだとマウント時に機能するわけではないためuseEffect使いたい
-  // => 使うとエラーになる
-  const getUserProfileImage = async () => {
-    const res = await fetch(
-      `${process.env.NEXT_PUBLIC_BACKEND_URL}/users/${userId}/profile_image`,
-      {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      }
-    )
-      .then((res) => {
-        if (!res.ok) {
-          throw '画像取得エラーがおきました。';
-        }
-        return res.blob();
-      })
-      .then((blobData) => {
-        // TODO Profile avatarの<img src>に変数を入れる
-        // 直接 GCS URLをsrc指定だと使い切りタイプ?のようなので
-        // 一意のURLを作成して変数化、ただし同じURL使って再度画像を取得することはできない
-
-        // 赤いボタンを押すとblobは生成されてる
-        const newAvatarImagePath = URL.createObjectURL(blobData);
-        console.log(newAvatarImagePath);
-        setAvatarImagePath(newAvatarImagePath);
-      });
-  };
-
   const updateUserProfileImage = async (file: File) => {
     const formData = new FormData();
     formData.append('image', file);
@@ -106,10 +77,9 @@ export const useUserInfo = (userId: string | null) => {
         body: formData,
       }
     );
-    // TODO APIでGCS登録されたデータが返ってきてそれをフロントのアバターに登録？
-    // Blob: {size:}が返ってきた
-    const data = await res.blob();
-    console.log(data);
+    setProfileImage(new Date().getTime());
+    // const data = await res.blob();
+    // console.log('updated data : ', data);
   };
   return {
     user,
@@ -117,7 +87,5 @@ export const useUserInfo = (userId: string | null) => {
     isLoading,
     error,
     updateUserProfileImage,
-    getUserProfileImage,
-    avatarImagePath,
   };
 };

--- a/src/components/hooks/useUserInfo.tsx
+++ b/src/components/hooks/useUserInfo.tsx
@@ -9,6 +9,7 @@ export const useUserInfo = (userId: string | null) => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   console.log('useUserInfo after ### useState ### user', user);
+  const [avatarImagePath, setAvatarImagePath] = useState('');
 
   useEffect(() => {
     setIsLoading(true);
@@ -62,7 +63,7 @@ export const useUserInfo = (userId: string | null) => {
     console.log('user userName', user?.userName); // 1週遅れ
   };
 
-  const getUserProfileImage = async (file: File) => {
+  const getUserProfileImage = async () => {
     const res = await fetch(
       `${process.env.NEXT_PUBLIC_BACKEND_URL}/users/${userId}/profile_image`,
       {
@@ -81,13 +82,12 @@ export const useUserInfo = (userId: string | null) => {
       .then((blobData) => {
         // TODO Profile avatarのsrcに変数を入れる
 
-        const avatarImagePath = URL.createObjectURL(blobData);
-        console.log(avatarImagePath);
-
-        // これだとブロック外では使えない
-        return avatarImagePath;
+        const newAvatarImagePath = URL.createObjectURL(blobData);
+        console.log(newAvatarImagePath);
+        setAvatarImagePath(newAvatarImagePath);
       });
   };
+  console.log();
 
   const updateUserProfileImage = async (file: File) => {
     const formData = new FormData();
@@ -113,5 +113,6 @@ export const useUserInfo = (userId: string | null) => {
     error,
     updateUserProfileImage,
     getUserProfileImage,
+    avatarImagePath,
   };
 };

--- a/src/components/hooks/useUserInfo.tsx
+++ b/src/components/hooks/useUserInfo.tsx
@@ -63,6 +63,8 @@ export const useUserInfo = (userId: string | null) => {
     console.log('user userName', user?.userName); // 1週遅れ
   };
 
+  // これだとマウント時に機能するわけではないためuseEffect使いたい
+  // => 使うとエラーになる
   const getUserProfileImage = async () => {
     const res = await fetch(
       `${process.env.NEXT_PUBLIC_BACKEND_URL}/users/${userId}/profile_image`,
@@ -87,7 +89,6 @@ export const useUserInfo = (userId: string | null) => {
         setAvatarImagePath(newAvatarImagePath);
       });
   };
-  console.log();
 
   const updateUserProfileImage = async (file: File) => {
     const formData = new FormData();

--- a/src/components/types/types.tsx
+++ b/src/components/types/types.tsx
@@ -1,6 +1,6 @@
 import { NextRouter } from 'next/router';
 import { ParsedUrlQuery } from 'querystring';
-import { Dispatch, ReactNode, SetStateAction } from 'react';
+import { ReactNode } from 'react';
 import { SetterOrUpdater } from 'recoil';
 
 export type Tatoe = {
@@ -62,7 +62,11 @@ export type TatoeBtnProps = {
 
 export type User = {
   userId: string | null;
-  userName: string | null;
+  userName: string | undefined;
+  email: string | undefined;
+  password: string | undefined;
+  createdAt: string | undefined;
+  updatedAt: string | undefined;
 };
 export type TatoeBtnHooksProps = {
   tatoe: Tatoe[];

--- a/src/components/utils/atoms/ProfileImageAtom.ts
+++ b/src/components/utils/atoms/ProfileImageAtom.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const ProfileImageAtom = atom({
+  key: 'profileImage',
+  default: new Date().getTime(),
+});


### PR DESCRIPTION
# Issue URL

#30 

# このPRの対応範囲

- #30 の通りに実装する。
- このPRでは登録・更新・読み出し・削除ができるようにする。
- ヘッダーのアバターアイコンに関してはこのPRで実装しない。

# 変更理由・変更内容

- 画像登録のストレージとして [Google Cloud Storage](https://cloud.google.com/products/storage/?utm_source=google&utm_medium=cpc&utm_campaign=japac-AU-all-en-dr-bkws-all-pkws-trial-e-dr-1009882&utm_content=text-ad-none-none-DEV_c-CRE_602407194719-ADGP_Hybrid%20%7C%20BKWS%20-%20EXA%20%7C%20Txt%20~%20Storage%20~%20Cloud%20Storage_storage-general%20-%20Products-KWID_43700071562401671-kwd-11642151515&userloc_1009336-network_g&utm_term=KW_google%20cloud%20storage&gclid=Cj0KCQjwpeaYBhDXARIsAEzItbE0xHbMvwcmagS8dZfQKapBI8-BOrVkMeQDVWKMM_MCNkgjyFxh4vMaAvulEALw_wcB&gclsrc=aw.ds)  を使う。理由としては、[Cloud Ace](https://cloud-ace.jp/column/detail26/)の記事の通り、初期は無料でAPIに制限なく使うことができることがあげられる。
