### PR TITLE
#73 非ログインユーザー・ログインユーザーがトップページと詳細ページで例え一覧を閲覧できるようにする。

### DIFF
--- a/src/components/Top/CardChild.tsx
+++ b/src/components/Top/CardChild.tsx
@@ -1,4 +1,4 @@
-import React, { VFC } from 'react';
+import React, { useEffect, useState, VFC } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { useHandleMoveToResult } from '../hooks/handleMoveToResult';
 import { Tatoe } from '../types/types';
@@ -7,9 +7,12 @@ import Image from 'next/image';
 import { useAuth } from '../hooks/useAuth';
 import { useUserInfo } from '../hooks/useUserInfo';
 import { ProfileImageAtom } from '../utils/atoms/ProfileImageAtom';
+import { useTatoe } from '../hooks/useTatoe';
+import { useRouter } from 'next/router';
+import { LoginUserAtom } from '../utils/atoms/LoginUserAtom';
 
 export const CardChild: VFC = () => {
-  const [tatoe, setTatoe] = useRecoilState<Tatoe[]>(TatoeAtom);
+  // const [tatoe, setTatoe] = useRecoilState<Tatoe[]>(TatoeAtom);
 
   const RandomColors = [
     'hover:shadow-plane_2xl_card_prime',
@@ -24,17 +27,135 @@ export const CardChild: VFC = () => {
 
   const { userId } = useAuth();
   const profileImage = useRecoilValue(ProfileImageAtom);
+  const [allUserTatoe, setAllUserTatoe] = useState([]);
 
   const { user } = useUserInfo(userId);
+  // ここから　getTatoeを使った実装　テスト
+  // 外からでも見られるように実装する => ログインユーザーの user いらない persistAccessToken いらない ?
+  useEffect(() => {
+    const main = async () => {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/tatoe`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+      const { tatoe } = await res.json();
+      console.log(tatoe);
 
-  if (!userId || !user) {
-    return null;
-  }
-  const userName = user.userName;
+      setAllUserTatoe(tatoe);
+    };
+    main();
+  }, []);
+
+  // これだとログアウトしたらリストが消える
+  // if (!userId || !user) {
+  //   return null;
+  // }
+  // const userName = user.userName;
 
   return (
     <>
-      {tatoe
+      {allUserTatoe
+        ? allUserTatoe.map((item: Tatoe) => (
+            <li
+              key={item.tId}
+              className={`
+                    px-4
+                    pt-4
+                    h-[312px]
+                    w-[280px]
+                    rounded-2xl
+                    shadow-plane_2xl_card
+                    ${shadowColor}
+                    border-[1px]
+                    border-gray-800
+                    bg-white
+                    `}
+              onClick={() =>
+                handleMoveToResult({
+                  tId: item.tId,
+                  title: item.title,
+                  shortParaphrase: item.shortParaphrase,
+                  description: item.description,
+                })
+              }
+            >
+              <ul
+                className='
+                        h-[72px]
+                        pl-1
+                        '
+              >
+                <li>
+                  <ul
+                    className='
+                    flex
+                    items-center
+                    gap-x-2
+                    pb-2
+                    '
+                  >
+                    <img
+                      src={`${process.env.NEXT_PUBLIC_BACKEND_URL}/users/${userId}/profile_image?t=${profileImage}`}
+                      alt='ユーザーの画像'
+                      className='
+                      w-6
+                      h-6
+                      rounded-full
+                      object-cover'
+                    />
+                    <p
+                      className='
+                    text-xs
+                    text-gray-400
+                    '
+                    >
+                      {item.userName}が投稿
+                    </p>
+                  </ul>
+                  <h3
+                    className='
+                                text-left
+                                text-dark_green
+                                text-lg
+                                '
+                  >
+                    {item.title}
+                    <br />
+                    <span className='text-gray-500'>を例えると...</span>
+                    {item.shortParaphrase}
+                  </h3>
+                </li>
+              </ul>
+              <ul
+                className='
+                        pt-5
+                        '
+              >
+                <li
+                  className='
+                            flex
+                            flex-col
+                            items-center
+                            pt-6
+                            '
+                >
+                  <Image
+                    src='/images/illust1.png'
+                    alt='illust of Tatoeba app'
+                    width={240}
+                    height={120}
+                    objectFit='contain'
+                    quality={50}
+                    priority={true}
+                  />
+                </li>
+              </ul>
+            </li>
+          ))
+        : undefined}
+      {/* {tatoe
         ? tatoe.map((item: Tatoe) => (
             <li
               key={item.tId}
@@ -132,7 +253,7 @@ export const CardChild: VFC = () => {
               </ul>
             </li>
           ))
-        : undefined}
+        : undefined} */}
     </>
   );
 };

--- a/src/components/Top/CardChild.tsx
+++ b/src/components/Top/CardChild.tsx
@@ -1,20 +1,13 @@
-import React, { SetStateAction, useEffect, useState, VFC } from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import React, { useEffect, useState, VFC } from 'react';
+import { useRecoilValue } from 'recoil';
 import { useHandleMoveToResult } from '../hooks/handleMoveToResult';
 import { Tatoe } from '../types/types';
-import { TatoeAtom } from '../utils/atoms/TatoeAtom';
 import Image from 'next/image';
-import { useAuth } from '../hooks/useAuth';
-import { useUserInfo } from '../hooks/useUserInfo';
+
 import { ProfileImageAtom } from '../utils/atoms/ProfileImageAtom';
-import { useTatoe } from '../hooks/useTatoe';
-import { useRouter } from 'next/router';
-import { LoginUserAtom } from '../utils/atoms/LoginUserAtom';
 import { useApi } from '../hooks/useApi';
 
 export const CardChild: VFC = () => {
-  // const [tatoe, setTatoe] = useRecoilState<Tatoe[]>(TatoeAtom);
-
   const RandomColors = [
     'hover:shadow-plane_2xl_card_prime',
     'hover:shadow-plane_2xl_card_second',
@@ -27,10 +20,7 @@ export const CardChild: VFC = () => {
   const [allUserTatoe, setAllUserTatoe] = useState<Tatoe[]>();
   const { handleMoveToResult } = useHandleMoveToResult(allUserTatoe);
 
-  const { userId } = useAuth();
   const profileImage = useRecoilValue(ProfileImageAtom);
-
-  const { user } = useUserInfo(userId);
 
   const { api: getUserTatoeApi } = useApi(`/tatoe`, {
     method: 'GET',
@@ -160,105 +150,6 @@ export const CardChild: VFC = () => {
             </li>
           ))
         : undefined}
-      {/* {tatoe
-        ? tatoe.map((item: Tatoe) => (
-            <li
-              key={item.tId}
-              className={`
-                    px-4
-                    pt-4
-                    h-[312px]
-                    w-[280px]
-                    rounded-2xl
-                    shadow-plane_2xl_card
-                    ${shadowColor}
-                    border-[1px]
-                    border-gray-800
-                    bg-white
-                    `}
-              onClick={() =>
-                handleMoveToResult({
-                  tId: item.tId,
-                  title: item.title,
-                  shortParaphrase: item.shortParaphrase,
-                  description: item.description,
-                })
-              }
-            >
-              <ul
-                className='
-                        h-[72px]
-                        pl-1
-                        '
-              >
-                <li>
-                  <ul
-                    className='
-                    flex
-                    items-center
-                    gap-x-2
-                    pb-2
-                    '
-                  >
-                    <img
-                      src={`${process.env.NEXT_PUBLIC_BACKEND_URL}/users/${userId}/profile_image?t=${profileImage}`}
-                      alt='ユーザーの画像'
-                      className='
-                      w-6
-                      h-6
-                      rounded-full
-                      object-cover'
-                    />
-                    <p
-                      className='
-                    text-xs
-                    text-gray-400
-                    '
-                    >
-                      {userName}が投稿
-                    </p>
-                  </ul>
-                  <h3
-                    className='
-                                text-left
-                                text-dark_green
-                                text-lg
-                                '
-                  >
-                    {item.title}
-                    <br />
-                    <span className='text-gray-500'>を例えると...</span>
-                    {item.shortParaphrase}
-                  </h3>
-                </li>
-              </ul>
-              <ul
-                className='
-                        pt-5
-                        '
-              >
-                <li
-                  className='
-                            flex
-                            flex-col
-                            items-center
-                            pt-6
-                            '
-                >
-                  <Image
-                    src='/images/illust1.png'
-                    alt='illust of Tatoeba app'
-                    width={240}
-                    height={120}
-                    objectFit='contain'
-                    quality={50}
-                    priority={true}
-                  />
-                </li>
-              </ul>
-            </li>
-          ))
-        : undefined} */}
     </>
   );
 };

--- a/src/components/Top/CardChild.tsx
+++ b/src/components/Top/CardChild.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image';
 
 import { ProfileImageAtom } from '../utils/atoms/ProfileImageAtom';
 import { useApi } from '../hooks/useApi';
+import { useGetUserTatoeApi } from '../hooks/useGetUserTatoeApi';
 
 export const CardChild: VFC = () => {
   const RandomColors = [
@@ -17,36 +18,45 @@ export const CardChild: VFC = () => {
 
   const colors = RandomColors[Math.floor(Math.random() * RandomColors.length)];
   const shadowColor = colors.toString();
-  const [allUserTatoe, setAllUserTatoe] = useState<Tatoe[]>();
+  // const [allUserTatoe, setAllUserTatoe] = useState<Tatoe[]>();
+
+  const { getAllUserTatoe, allUserTatoe } = useGetUserTatoeApi();
   const { handleMoveToResult } = useHandleMoveToResult(allUserTatoe);
 
   const profileImage = useRecoilValue(ProfileImageAtom);
 
-  const { api: getUserTatoeApi } = useApi(`/tatoe`, {
-    method: 'GET',
-  });
+  // const { api: getUserTatoeApi } = useApi(`/tatoe`, {
+  //   method: 'GET',
+  // });
 
   // TODO Prisma Tatoeモデル にuserNameを登録しないといけない
 
   useEffect(() => {
     const main = async () => {
-      const { tatoe } = await getUserTatoeApi();
-      const formattedTatoe = tatoe.map((item: any) => {
-        const formattedData = {
-          tId: item.id,
-          userId: item.userId,
-          createdAt: item.createdAt,
-          updatedAt: item.updatedAt,
-          title: item.title,
-          description: item.description,
-          shortParaphrase: item.shortParaphrase,
-        };
-        return formattedData;
-      });
-      setAllUserTatoe(formattedTatoe);
+      await getAllUserTatoe();
     };
     main();
   }, []);
+
+  // useEffect(() => {
+  //   const main = async () => {
+  //     const { tatoe } = await getUserTatoeApi();
+  //     const formattedTatoe = tatoe.map((item: any) => {
+  //       const formattedData = {
+  //         tId: item.id,
+  //         userId: item.userId,
+  //         createdAt: item.createdAt,
+  //         updatedAt: item.updatedAt,
+  //         title: item.title,
+  //         description: item.description,
+  //         shortParaphrase: item.shortParaphrase,
+  //       };
+  //       return formattedData;
+  //     });
+  //     setAllUserTatoe(formattedTatoe);
+  //   };
+  //   main();
+  // }, []);
 
   return (
     <>

--- a/src/components/hooks/handleMoveToResult.tsx
+++ b/src/components/hooks/handleMoveToResult.tsx
@@ -1,25 +1,22 @@
-import { NextRouter, useRouter } from 'next/router';
-import { ParsedUrlQuery } from 'querystring';
-import { useRecoilState } from 'recoil';
+import { useRouter } from 'next/router';
 import { Tatoe } from '../types/types';
-import { TatoeAtom } from '../utils/atoms/TatoeAtom';
 
-export const useHandleMoveToResult = () => {
-  const [tatoe, setTatoe] = useRecoilState<Tatoe[]>(TatoeAtom);
+export const useHandleMoveToResult = (allUserTatoe: Tatoe[]) => {
   const router = useRouter();
 
   const handleMoveToResult = (props: Tatoe) => {
-    const { tId, title, shortParaphrase, description } = props;
+    const { tId, title, shortParaphrase, description, userId } = props;
 
-    tatoe.forEach((item: Tatoe) => {
+    allUserTatoe.forEach((item: Tatoe) => {
       if (item.tId === tId) {
         router.push({
-          pathname: '/SearchResult/[tId]/',
+          pathname: '/SearchResult/[tId]',
           query: {
             tId,
             title,
             shortParaphrase,
             description,
+            userId,
           },
         });
       }

--- a/src/components/hooks/useApi.tsx
+++ b/src/components/hooks/useApi.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { LoginUserAtom } from '../utils/atoms/LoginUserAtom';
 
@@ -16,7 +17,7 @@ export const useApi = (url: string, { method }: UseApiOptions) => {
         Authorization: `Bearer ${persistAccessToken}`,
       },
 
-      body: JSON.stringify(sendData),
+      body: method === 'GET' ? null : JSON.stringify(sendData),
     });
     const data = await res.json();
     return data;

--- a/src/components/hooks/useGetUserTatoeApi.tsx
+++ b/src/components/hooks/useGetUserTatoeApi.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+import { useRecoilState } from 'recoil';
+import { Tatoe } from '../types/types';
+import { AllUserTatoeAtom } from '../utils/atoms/AllUserTatoeAtom';
+import { useApi } from './useApi';
+
+export const useGetUserTatoeApi = (filteredTatoe?: Tatoe[], url?: string) => {
+  const { api: getAllUserTatoesApi } = useApi(`/tatoe`, {
+    method: 'GET',
+  });
+
+  const [allUserTatoe, setAllUserTatoe] = useRecoilState(AllUserTatoeAtom);
+
+  const getAllUserTatoe = async () => {
+    const { tatoe } = await getAllUserTatoesApi();
+
+    const formattedTatoe = tatoe.map((item: any) => {
+      const formattedData = {
+        tId: item.id,
+        userId: item.userId,
+        createdAt: item.createdAt,
+        updatedAt: item.updatedAt,
+        title: item.title,
+        description: item.description,
+        shortParaphrase: item.shortParaphrase,
+      };
+      return formattedData;
+    });
+    setAllUserTatoe(formattedTatoe);
+  };
+
+  const getEachTatoe = async () => {
+    if (!filteredTatoe) return;
+    const { api: getEachTatoeApi } = useApi(
+      `/tatoe/${filteredTatoe[0]['tId']}`,
+      {
+        method: 'GET',
+      }
+    );
+    const { tatoe } = await getEachTatoeApi();
+
+    const formattedTatoe: Tatoe[] = tatoe.map((item: any) => {
+      const formattedData = {
+        tId: item.id,
+        userId: item.userId,
+        createdAt: item.createdAt,
+        updatedAt: item.updatedAt,
+        title: item.title,
+        description: item.description,
+        shortParaphrase: item.shortParaphrase,
+      };
+      return formattedData;
+    });
+    setAllUserTatoe(formattedTatoe);
+  };
+  return { getAllUserTatoe, getEachTatoe, allUserTatoe };
+};

--- a/src/components/utils/atoms/AllUserTatoeAtom.ts
+++ b/src/components/utils/atoms/AllUserTatoeAtom.ts
@@ -1,0 +1,11 @@
+import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+
+const { persistAtom } = recoilPersist();
+
+export const AllUserTatoeAtom = atom({
+  key: 'allUserTatoe',
+  default: [],
+
+  effects_UNSTABLE: [persistAtom],
+});

--- a/src/pages/SearchResult/SearchResultList.tsx
+++ b/src/pages/SearchResult/SearchResultList.tsx
@@ -8,35 +8,50 @@ import { useRouter } from 'next/router';
 import { useRecoilState } from 'recoil';
 import { TatoeAtom } from '../../components/utils/atoms/TatoeAtom';
 import { Tatoe } from '../../components/types/types';
+import { useApi } from '../../components/hooks/useApi';
+import { useGetUserTatoeApi } from '../../components/hooks/useGetUserTatoeApi';
 
 const SearchResultList = () => {
-  const [tatoe, setTatoe] = useRecoilState<Tatoe[]>(TatoeAtom);
+  // const [tatoe, setTatoe] = useRecoilState<Tatoe[]>(TatoeAtom);
   const [result, setResult] = useState([]);
-  // const [ result, setResult ] = useRecoilState(SearchResultAtom)
+
   const router = useRouter();
 
-  //router query を１回だけ取得したい。toStringがquery = undefinedの時に機能しない
-  console.log(router.query.keyWord);
-  //1回目入力した値　2回目reload undefined
-  //1回目の状態を保持したい
-
-  const queryKeyWord: string = router.query.keyWord.toString();
+  // const queryKeyWord: string = router.query.keyWord.toString();
+  const queryKeyWord: string = router.query.keyWord as string;
 
   const [keyWord, setKeyWord] = useState(queryKeyWord);
+  const [filteredTatoe, setFilteredTatoe] = useState<Tatoe[] | undefined>();
+
+  // useEffect(() => {
+  //   if (!router.query.tId) return;
+  //   const main = async () => {
+  //     const { data: tatoe } = await getTatoeApi();
+  //     setTatoe(tatoe);
+  //   };
+  //   main();
+  // }, [router.query.tId]);
+  const { getEachTatoe, allUserTatoe } = useGetUserTatoeApi(filteredTatoe);
 
   useEffect(() => {
+    const main = async () => {
+      await getEachTatoe();
+    };
+    main();
+
+    if (!allUserTatoe) return;
     if (keyWord) {
-      const filteredTatoe = tatoe.filter((item: Tatoe) => {
+      const newFilteredTatoe = allUserTatoe.filter((item: Tatoe) => {
         return (
           item.title.toLowerCase().indexOf(keyWord) !== -1 ||
           item.description.toLowerCase().indexOf(keyWord) !== -1 ||
           item.shortParaphrase.toLowerCase().indexOf(keyWord) !== -1
         );
       });
-      setResult([...result].concat(filteredTatoe));
+      setResult([...result].concat(newFilteredTatoe));
+      setFilteredTatoe(newFilteredTatoe);
     }
   }, [router.query.keyWord]);
-
   return (
     <>
       <Head>

--- a/src/pages/SearchResult/[tid]/index.tsx
+++ b/src/pages/SearchResult/[tid]/index.tsx
@@ -4,11 +4,8 @@ import { useRouter } from 'next/router';
 import 'tailwindcss/tailwind.css';
 import { Header } from '../../../components/Header/Header';
 import { SearchMainLayouts } from '../../../components/Layouts/SearchMainLayouts';
-import { useRecoilState, useRecoilValue } from 'recoil';
-import { UserNameAtom } from '../../../components/utils/atoms/UserNameAtom';
-import Image from 'next/image';
-import { useUserInfo } from '../../../components/hooks/useUserInfo';
-import { useAuth } from '../../../components/hooks/useAuth';
+import { useRecoilValue } from 'recoil';
+
 import { ProfileImageAtom } from '../../../components/utils/atoms/ProfileImageAtom';
 import { useApi } from '../../../components/hooks/useApi';
 

--- a/src/pages/SearchResult/[tid]/index.tsx
+++ b/src/pages/SearchResult/[tid]/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import 'tailwindcss/tailwind.css';
@@ -10,18 +10,26 @@ import Image from 'next/image';
 import { useUserInfo } from '../../../components/hooks/useUserInfo';
 import { useAuth } from '../../../components/hooks/useAuth';
 import { ProfileImageAtom } from '../../../components/utils/atoms/ProfileImageAtom';
+import { useApi } from '../../../components/hooks/useApi';
 
 const SearchResult = () => {
   const router = useRouter();
   const profileImage = useRecoilValue(ProfileImageAtom);
-  const { title, shortParaphrase, description } = router.query;
-  // const userName = useRecoilState(UserNameAtom);
-  const { userId } = useAuth();
-  const { user } = useUserInfo(userId);
+  const { title, shortParaphrase, description, userId } = router.query;
 
-  if (!userId || !user) {
-    return null;
-  }
+  const [tatoe, setTatoe] = useState();
+  const { api: getTatoeApi } = useApi(`/tatoe/${router.query.tId}`, {
+    method: 'GET',
+  });
+
+  useEffect(() => {
+    if (!router.query.tId) return;
+    const main = async () => {
+      const { data: tatoe } = await getTatoeApi();
+      setTatoe(tatoe);
+    };
+    main();
+  }, [router.query.tId]);
 
   return (
     <>
@@ -43,7 +51,7 @@ const SearchResult = () => {
                 rounded-full
                 object-cover'
               />
-              <small className='text-gray-400'>{user.userName}が投稿</small>
+              {/* <small className='text-gray-400'>{user.userName}が投稿</small> */}
             </div>
             <div
               className='


### PR DESCRIPTION
# Issue URL

#73  

# このPRの対応範囲

- #73 のとおり実装する。
- 詳細ページのアバターはこのPRでは未実装のため、別のPRで実装する。

# 変更理由・変更内容

- 今まではログインユーザーがログインするとトップページ、検索結果、詳細ページに例えが表示され閲覧できるようになっていたが、非ログインユーザーやログインしているユーザー本人以外のログインユーザーも閲覧できるようにしたいので、その実装をした。