### PR TITLE
#73 ダッシュボードで他のユーザーの例えを閲覧できる状態になっていたため、閲覧できないようにした。キャッシュのリセットしても例え一覧が消えないように実装した。

### DIFF
--- a/src/components/DashBoard/TatoeList.tsx
+++ b/src/components/DashBoard/TatoeList.tsx
@@ -17,10 +17,14 @@ export const TatoeList = (): JSX.Element => {
   const persistAccessToken = useRecoilValue(LoginUserAtom);
   const router = useRouter();
   const [tatoe, setTatoe] = useRecoilState<Tatoe[]>(TatoeAtom);
+  console.log('@TatoeList tatoe + : ', tatoe);
+
   if (!userId) {
     return null;
   }
+
   const { getTatoe } = useTatoe({
+    userId,
     tatoe,
     router,
     user,
@@ -31,6 +35,8 @@ export const TatoeList = (): JSX.Element => {
   useEffect(() => {
     const getUserTatoeList = async () => {
       await getTatoe();
+
+      // setTatoe(newTatoe);
     };
     getUserTatoeList();
   }, []);

--- a/src/components/btn/TatoeListEditExistingTatoeBtn.tsx
+++ b/src/components/btn/TatoeListEditExistingTatoeBtn.tsx
@@ -1,15 +1,23 @@
 import React, { VFC } from 'react';
 import { useHandleMoveToEdit } from '../hooks/handleMoveToEdit';
+import { Tatoe } from '../types/types';
 
-export type EditBtnProps = {
-  readonly tId: string;
-  title: string;
-  shortParaphrase: string;
-  description: string;
-};
+// export type EditBtnProps = {
+//   readonly tId: string;
+//   title: string;
+//   shortParaphrase: string;
+//   description: string;
+// };
 
-export const TatoeListEditExistingTatoeBtn: VFC<EditBtnProps> = (props) => {
-  const { tId, title, shortParaphrase, description } = props;
+export const TatoeListEditExistingTatoeBtn = ({
+  tId,
+  title,
+  shortParaphrase,
+  description,
+}: Tatoe) => {
+  console.log('編集ボタン大元　tId :', tId);
+
+  // const { tId, title, shortParaphrase, description } = props;
   const { handleMoveToEdit } = useHandleMoveToEdit({
     tId,
     title,

--- a/src/components/hooks/handleMoveToEdit.tsx
+++ b/src/components/hooks/handleMoveToEdit.tsx
@@ -2,18 +2,15 @@ import { useRouter } from 'next/router';
 import { ParsedUrlQuery } from 'querystring';
 import { Tatoe } from '../types/types';
 
-export const useHandleMoveToEdit = (props: {
-  tId: string;
-  title: string;
-  shortParaphrase: string;
-  description: string;
-}) => {
+export const useHandleMoveToEdit = ({
+  tId,
+  title,
+  shortParaphrase,
+  description,
+}: Tatoe) => {
   const router = useRouter();
   const handleMoveToEdit = () => {
-    const tId = props.tId;
-    const title = props.title;
-    const shortParaphrase = props.shortParaphrase;
-    const description = props.description;
+    console.log('@useHandleMoveToEdit tId +++ : ', tId); // undefined
 
     router.push({
       pathname: '/Register/',

--- a/src/components/hooks/useTatoe.tsx
+++ b/src/components/hooks/useTatoe.tsx
@@ -5,6 +5,7 @@ import { useApi } from './useApi';
 
 export const useTatoe = (props: TatoeBtnHooksProps) => {
   const { tId, userId, query_tId } = props;
+  const [tatoe, setTatoe] = useRecoilState(TatoeAtom);
 
   const { api: postTatoeApi } = useApi('/tatoe', { method: 'POST' });
   const { api: getTatoeApi } = useApi(`/users/${userId}/tatoe`, {
@@ -14,10 +15,34 @@ export const useTatoe = (props: TatoeBtnHooksProps) => {
     method: 'PUT',
   });
   const { api: deleteTatoeApi } = useApi(`/tatoe/${tId}`, { method: 'DELETE' });
-  const [tatoe, setTatoe] = useRecoilState(TatoeAtom);
 
   const getTatoe = async () => {
     const { data } = await getTatoeApi();
+
+    const newData = data.map((item: any) => {
+      return {
+        tId: item.id,
+        userId: item.userId,
+        createdAt: item.createdAt,
+        updatedAt: item.updatedAt,
+        title: item.title,
+        description: item.description,
+        shortParaphrase: item.shortParaphrase,
+      };
+    });
+
+    const sortedData = newData.sort((a: Tatoe, b: Tatoe) => {
+      if (a.createdAt < b.createdAt) {
+        return 1;
+      }
+      if (a.createdAt > b.createdAt) {
+        return -1;
+      }
+      return 0;
+    });
+
+    setTatoe(sortedData);
+
     if (!data) {
       throw Error('データがありません');
     }


### PR DESCRIPTION
# Issue URL

#75 

# このPRの対応範囲

- #75 のとおりに実装する。

# 変更理由・変更内容

ダッシュボードで他のユーザーの例えを閲覧できる状態になっていたため、閲覧できないようにした。
また、キャッシュのリセットをしても例え一覧が消えないように実装した。

- APIからGETメソッドで例え一覧を表示しておらず、Recoilで実装している部分があったためそれをAPIからのレスポンスデータへ置き換えた。
