### PR TITLE
#83 .gitignoreで.envを追跡対象外にしていたにも関わらず追跡されていたため、キャッシュ削除

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-NEXT_PUBLIC_BACKEND_URL=http://localhost:3003

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env
 .env
+/.env
 
 # vercel
 .vercel


### PR DESCRIPTION
# Issue URL

#83 

# このPRの対応範囲

- .gitignoreで.envを追跡対象外にしていたにも関わらず追跡されていたため、キャッシュ削除

# 変更理由・変更内容

- .envがリモートリポジトリにあり、セキュリティ上危険なので以下の方法で追跡対象外にした。

```
$ git rm -r --cached .env
$ git commit -m"ignore .env file"
$ git push ~~~
```