### PR TITLE
#80 トップページと詳細ページでuserNameが受け取れるようにした。

### DIFF
--- a/src/components/Top/CardChild.tsx
+++ b/src/components/Top/CardChild.tsx
@@ -30,7 +30,6 @@ export const CardChild: VFC = () => {
     };
     main();
   }, []);
-  console.log('@CardChild allUserTatoe', allUserTatoe);
 
   return (
     <>

--- a/src/components/Top/CardChild.tsx
+++ b/src/components/Top/CardChild.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, VFC } from 'react';
 import { useRecoilValue } from 'recoil';
 import { useHandleMoveToResult } from '../hooks/handleMoveToResult';
-import { Tatoe } from '../types/types';
+import { AllUserTatoe, Tatoe } from '../types/types';
 import Image from 'next/image';
 
 import { ProfileImageAtom } from '../utils/atoms/ProfileImageAtom';
@@ -18,18 +18,11 @@ export const CardChild: VFC = () => {
 
   const colors = RandomColors[Math.floor(Math.random() * RandomColors.length)];
   const shadowColor = colors.toString();
-  // const [allUserTatoe, setAllUserTatoe] = useState<Tatoe[]>();
 
   const { getAllUserTatoe, allUserTatoe } = useGetUserTatoeApi();
   const { handleMoveToResult } = useHandleMoveToResult(allUserTatoe);
 
   const profileImage = useRecoilValue(ProfileImageAtom);
-
-  // const { api: getUserTatoeApi } = useApi(`/tatoe`, {
-  //   method: 'GET',
-  // });
-
-  // TODO Prisma Tatoeモデル にuserNameを登録しないといけない
 
   useEffect(() => {
     const main = async () => {
@@ -37,31 +30,12 @@ export const CardChild: VFC = () => {
     };
     main();
   }, []);
-
-  // useEffect(() => {
-  //   const main = async () => {
-  //     const { tatoe } = await getUserTatoeApi();
-  //     const formattedTatoe = tatoe.map((item: any) => {
-  //       const formattedData = {
-  //         tId: item.id,
-  //         userId: item.userId,
-  //         createdAt: item.createdAt,
-  //         updatedAt: item.updatedAt,
-  //         title: item.title,
-  //         description: item.description,
-  //         shortParaphrase: item.shortParaphrase,
-  //       };
-  //       return formattedData;
-  //     });
-  //     setAllUserTatoe(formattedTatoe);
-  //   };
-  //   main();
-  // }, []);
+  console.log('@CardChild allUserTatoe', allUserTatoe);
 
   return (
     <>
       {allUserTatoe
-        ? allUserTatoe.map((item: Tatoe) => (
+        ? allUserTatoe.map((item: AllUserTatoe) => (
             <li
               key={item.tId}
               className={`

--- a/src/components/hooks/useGetUserTatoeApi.tsx
+++ b/src/components/hooks/useGetUserTatoeApi.tsx
@@ -1,5 +1,5 @@
 import { useRecoilState } from 'recoil';
-import { Tatoe } from '../types/types';
+import { AllUserTatoe, Tatoe } from '../types/types';
 import { AllUserTatoeAtom } from '../utils/atoms/AllUserTatoeAtom';
 import { useApi } from './useApi';
 
@@ -12,6 +12,7 @@ export const useGetUserTatoeApi = (filteredTatoe?: Tatoe[]) => {
 
   const getAllUserTatoe = async () => {
     const { tatoe } = await getAllUserTatoesApi();
+    console.log('getAllUserTatoesApi tatoe', tatoe);
 
     const formattedTatoe = tatoe.map((item: any) => {
       const formattedData = {
@@ -22,6 +23,7 @@ export const useGetUserTatoeApi = (filteredTatoe?: Tatoe[]) => {
         title: item.title,
         description: item.description,
         shortParaphrase: item.shortParaphrase,
+        userName: item.user.userName,
       };
       return formattedData;
     });
@@ -39,7 +41,7 @@ export const useGetUserTatoeApi = (filteredTatoe?: Tatoe[]) => {
     );
     const { tatoe } = await getEachTatoeApi();
 
-    const formattedTatoe: Tatoe[] = tatoe.map((item: any) => {
+    const formattedTatoe: AllUserTatoe[] = tatoe.map((item: any) => {
       const formattedData = {
         tId: item.id,
         userId: item.userId,
@@ -50,10 +52,13 @@ export const useGetUserTatoeApi = (filteredTatoe?: Tatoe[]) => {
         shortParaphrase: item.shortParaphrase,
         imageId: item.imageId,
         imageUrl: item.imageUrl,
+        userName: item.user.userName,
       };
       return formattedData;
     });
     setAllUserTatoe(formattedTatoe);
   };
+  console.log('allUserTatoe', allUserTatoe);
+
   return { getAllUserTatoe, getEachTatoe, allUserTatoe };
 };

--- a/src/components/hooks/useGetUserTatoeApi.tsx
+++ b/src/components/hooks/useGetUserTatoeApi.tsx
@@ -12,7 +12,6 @@ export const useGetUserTatoeApi = (filteredTatoe?: Tatoe[]) => {
 
   const getAllUserTatoe = async () => {
     const { tatoe } = await getAllUserTatoesApi();
-    console.log('getAllUserTatoesApi tatoe', tatoe);
 
     const formattedTatoe = tatoe.map((item: any) => {
       const formattedData = {
@@ -58,7 +57,6 @@ export const useGetUserTatoeApi = (filteredTatoe?: Tatoe[]) => {
     });
     setAllUserTatoe(formattedTatoe);
   };
-  console.log('allUserTatoe', allUserTatoe);
 
   return { getAllUserTatoe, getEachTatoe, allUserTatoe };
 };

--- a/src/components/types/types.tsx
+++ b/src/components/types/types.tsx
@@ -17,6 +17,21 @@ export type Tatoe = {
   formData?: FormData;
 };
 
+export type AllUserTatoe = {
+  tId?: string;
+  userId?: string;
+  title?: string;
+  shortParaphrase?: string;
+  description?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  imageUrl?: string;
+  imageId?: string;
+  query_tId?: string | string[];
+  formData?: FormData;
+  userName: string;
+};
+
 export type Edit = {
   handleMoveToEdit: (
     tId: string,

--- a/src/pages/SearchResult/[tid]/index.tsx
+++ b/src/pages/SearchResult/[tid]/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import 'tailwindcss/tailwind.css';
@@ -7,27 +7,23 @@ import { SearchMainLayouts } from '../../../components/Layouts/SearchMainLayouts
 import { useRecoilValue } from 'recoil';
 
 import { ProfileImageAtom } from '../../../components/utils/atoms/ProfileImageAtom';
-import { useApi } from '../../../components/hooks/useApi';
+import { useGetUserTatoeApi } from '../../../components/hooks/useGetUserTatoeApi';
+import { AllUserTatoe } from '../../../components/types/types';
 
 const SearchResult = () => {
   const router = useRouter();
   const profileImage = useRecoilValue(ProfileImageAtom);
-  const { title, shortParaphrase, description, userId } = router.query;
+  const { tId } = router.query;
 
-  const [tatoe, setTatoe] = useState();
-  const { api: getTatoeApi } = useApi(`/tatoe/${router.query.tId}`, {
-    method: 'GET',
-  });
+  const { getAllUserTatoe, allUserTatoe } = useGetUserTatoeApi();
 
-  // TODO サーバー側で用意したデフォルト画像が、リロード時に少し出る
   useEffect(() => {
-    if (!router.query.tId) return;
+    if (!tId) return;
     const main = async () => {
-      const { data: tatoe } = await getTatoeApi();
-      setTatoe(tatoe);
+      await getAllUserTatoe();
     };
     main();
-  }, [router.query.tId]);
+  }, [tId]);
 
   return (
     <>
@@ -37,52 +33,58 @@ const SearchResult = () => {
       </Head>
       <Header />
       <SearchMainLayouts>
-        <div>
-          <div className='flex flex-col'>
-            <div className='flex items-center gap-x-2'>
-              <img
-                src={`${process.env.NEXT_PUBLIC_BACKEND_URL}/users/${userId}/profile_image?t=${profileImage}`}
-                alt='ユーザーの画像'
-                className='
+        {allUserTatoe.map((item: AllUserTatoe) => {
+          return item.tId === tId ? (
+            <div key={item.tId}>
+              <div className='flex flex-col'>
+                <div className='flex items-center gap-x-2'>
+                  <img
+                    src={`${process.env.NEXT_PUBLIC_BACKEND_URL}/users/${item.userId}/profile_image?t=${profileImage}`}
+                    alt='ユーザーの画像'
+                    className='
                 w-6
                 h-6
                 rounded-full
                 object-cover'
-              />
-              {/* <small className='text-gray-400'>{user.userName}が投稿</small> */}
-            </div>
-            <div
-              className='
+                  />
+                  <small className='text-gray-400'>{item.userName}が投稿</small>
+                </div>
+                <div
+                  className='
                flex
                relative
                '
-            >
-              <h1
-                className='
+                >
+                  <h1
+                    className='
                   text-4xl
                   text-gray-700
                   pt-6
                   '
-              >
-                {title}
-                をわかりやすく例えると...
-              </h1>
-            </div>
-          </div>
-          <h2 className='pt-16 text-2xl text-gray-600'>{shortParaphrase}</h2>
-          <p
-            className='
+                  >
+                    {item.title}
+                    をわかりやすく例えると...
+                  </h1>
+                </div>
+              </div>
+              <h2 className='pt-16 text-2xl text-gray-600'>
+                {item.shortParaphrase}
+              </h2>
+              <p
+                className='
             pt-10
             text-md
             leading-loose
             text-gray-600'
-          >
-            {description}
-          </p>
-          <div className='max-w-[600px] h-96 bg-gray-300 mx-auto'>
-            <img />
-          </div>
-        </div>
+              >
+                {item.description}
+              </p>
+              <div className='max-w-[600px] h-96 bg-gray-300 mx-auto'>
+                <img />
+              </div>
+            </div>
+          ) : null;
+        })}
       </SearchMainLayouts>
     </>
   );


### PR DESCRIPTION
# Issue URL

#80 

# このPRの対応範囲

- #80 のとおり、トップページと詳細ページでuserNameが受け取れるようにする。
- 説明画像の実装はこのPRおよびIssueではしていない。 

# 変更理由・変更内容

- 以前は`getTatoeApi`を呼んでいたが、こちらはuser個人のダッシュボードで呼ぶべきAPIだったため、`getAllUserTatoeApi`に置き換えた。
- router query paramsを使って値を取得していたが、それだと書き換えが可能になってしまうため、扱う値の部分を最小限にした。