### PR TITLE
#81 トップページと詳細ページの説明画像をAPI経由で表示する。

### DIFF
--- a/src/components/Top/CardChild.tsx
+++ b/src/components/Top/CardChild.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState, VFC } from 'react';
+import React, { useEffect, VFC } from 'react';
 import { useRecoilValue } from 'recoil';
 import { useHandleMoveToResult } from '../hooks/handleMoveToResult';
-import { AllUserTatoe, Tatoe } from '../types/types';
+import { AllUserTatoe } from '../types/types';
 import Image from 'next/image';
 
 import { ProfileImageAtom } from '../utils/atoms/ProfileImageAtom';
@@ -30,6 +30,7 @@ export const CardChild: VFC = () => {
     };
     main();
   }, []);
+  console.log(allUserTatoe);
 
   return (
     <>
@@ -119,7 +120,7 @@ export const CardChild: VFC = () => {
                             pt-6
                             '
                 >
-                  <Image
+                  {/* <Image
                     src='/images/illust1.png'
                     alt='illust of Tatoeba app'
                     width={240}
@@ -127,7 +128,8 @@ export const CardChild: VFC = () => {
                     objectFit='contain'
                     quality={50}
                     priority={true}
-                  />
+                  /> */}
+                  <img src={item.imageUrl} alt='例えの説明画像' />
                 </li>
               </ul>
             </li>

--- a/src/components/hooks/useGetUserTatoeApi.tsx
+++ b/src/components/hooks/useGetUserTatoeApi.tsx
@@ -11,9 +11,9 @@ export const useGetUserTatoeApi = (filteredTatoe?: Tatoe[]) => {
   const [allUserTatoe, setAllUserTatoe] = useRecoilState(AllUserTatoeAtom);
 
   const getAllUserTatoe = async () => {
-    const { tatoe } = await getAllUserTatoesApi();
+    const { data } = await getAllUserTatoesApi();
 
-    const formattedTatoe = tatoe.map((item: any) => {
+    const formattedTatoe = data.map((item: any) => {
       const formattedData = {
         tId: item.id,
         userId: item.userId,
@@ -23,6 +23,7 @@ export const useGetUserTatoeApi = (filteredTatoe?: Tatoe[]) => {
         description: item.description,
         shortParaphrase: item.shortParaphrase,
         userName: item.user.userName,
+        imageUrl: item.imageUrl,
       };
       return formattedData;
     });

--- a/src/pages/SearchResult/[tid]/index.tsx
+++ b/src/pages/SearchResult/[tid]/index.tsx
@@ -80,7 +80,7 @@ const SearchResult = () => {
                 {item.description}
               </p>
               <div className='max-w-[600px] h-96 bg-gray-300 mx-auto'>
-                <img />
+                <img src={item.imageUrl} alt='例えの説明画像' />
               </div>
             </div>
           ) : null;


### PR DESCRIPTION
# Issue URL

#81 

# このPRの対応範囲

- #81 のとおりに実装する。
- 画像の位置やページ内の余白などレイアウト調整を行うためのPRは別のPRで対応する。

# 変更理由・変更内容

API経由で下記のとおり画像を表示することに成功した。

<a href="https://gyazo.com/ec5d4ee6f23c658f0ade44305fab6e80"><img src="https://i.gyazo.com/ec5d4ee6f23c658f0ade44305fab6e80.gif" alt="Image from Gyazo" width="840"/></a>