### PR TITLE
#90 例えの登録・更新・削除・読み出し周りのリファクタ

### DIFF
--- a/src/components/DashBoard/Tatoe/TatoeForm.tsx
+++ b/src/components/DashBoard/Tatoe/TatoeForm.tsx
@@ -48,7 +48,7 @@ export const TatoeForm = ({
   updatedAt,
 }: TatoeFormProps) => {
   const [isUpdate, setIsUpdate] = useState<boolean>(false);
-  console.log(tId);
+
   useEffect(() => {
     if (tId) {
       setIsUpdate(true);
@@ -111,25 +111,22 @@ export const TatoeForm = ({
       />
       <div className='mx-auto md:mx-0 md:justify-end pt-6 flex flex-col smd:flex-row gap-6'>
         <RegisterTatoeBtn
-          role='cancel'
+          variant='cancel'
           btnName='キャンセル'
-          btnColor='white'
           btnType='button'
           tId={tId}
           tatoe={tatoe}
           onClickCancel={handleClickCancel}
         />
-        {isUpdate ? (
+        {!isUpdate ? (
           <RegisterTatoeBtn
-            role='create'
-            btnColor='black'
+            variant='create'
             btnName='投稿する'
             btnType='submit'
           />
         ) : (
           <RegisterTatoeBtn
-            role='update'
-            btnColor='black'
+            variant='update'
             btnName='更新する'
             btnType='submit'
             tId={tId}
@@ -141,21 +138,6 @@ export const TatoeForm = ({
             description={description}
           />
         )}
-
-        {/* <CancelTatoeBtn tId={tId} /> */}
-        {/* {!isUpdate ? (
-          <CreateTatoeBtn />
-        ) : (
-          <UpdateTatoeBtn
-            tatoe={tatoe}
-            tId={tId}
-            createdAt={createdAt}
-            updatedAt={updatedAt}
-            title={title}
-            shortParaphrase={shortParaphrase}
-            description={description}
-          />
-        )} */}
       </div>
     </form>
   );

--- a/src/components/DashBoard/Tatoe/TatoeForm.tsx
+++ b/src/components/DashBoard/Tatoe/TatoeForm.tsx
@@ -1,4 +1,4 @@
-import { useRouter } from 'next/router';
+// import { useRouter } from 'next/router';
 import React, {
   Dispatch,
   FormEventHandler,
@@ -7,6 +7,7 @@ import React, {
   useEffect,
   useState,
 } from 'react';
+import { SetterOrUpdater } from 'recoil';
 import { RegisterImageForExplanationTatoe } from '../../../pages/Register/RegisterTatoeChild/RegisterImageForExplanationTatoe';
 import { RegisterTatoeDescription } from '../../../pages/Register/RegisterTatoeChild/RegisterTatoeDescription';
 import { RegisterTatoeShortParaphrase } from '../../../pages/Register/RegisterTatoeChild/RegisterTatoeShortParaphrase';
@@ -14,6 +15,7 @@ import { RegisterTatoeTitle } from '../../../pages/Register/RegisterTatoeChild/R
 // import { CancelTatoeBtn } from '../../btn/CancelTatoeBtn';
 // import { CreateTatoeBtn } from '../../btn/CreateTatoeBtn';
 import { RegisterTatoeBtn } from '../../btn/RegisterTatoeBtn';
+import { useTatoeCancel } from '../../hooks/useTatoeCancel';
 // import { UpdateTatoeBtn } from '../../btn/UpdateTatoeBtn';
 import { Tatoe } from '../../types/types';
 
@@ -27,6 +29,7 @@ type TatoeFormProps = {
   setDefaultImageUrl: Dispatch<SetStateAction<string | null>>;
   deleteExplanationImage?: MouseEventHandler<HTMLButtonElement>;
   tatoe?: Tatoe[];
+  setTatoe?: SetterOrUpdater<Tatoe[]>;
 } & Tatoe;
 
 export const TatoeForm = ({
@@ -44,6 +47,7 @@ export const TatoeForm = ({
   deleteExplanationImage,
   tId,
   tatoe,
+  setTatoe,
   createdAt,
   updatedAt,
 }: TatoeFormProps) => {
@@ -55,41 +59,43 @@ export const TatoeForm = ({
     }
   }, [tId]);
 
-  // cancel btn あとでけす
-  const router = useRouter();
+  const { handleClickCancel } = useTatoeCancel({ tId, tatoe, setTatoe });
 
-  // const [tatoe, setTatoe] = useRecoilState<Tatoe[]>(TatoeAtom);
+  // // cancel btn あとでけす
+  // const router = useRouter();
 
-  const handleClickCancel = () => {
-    if (tId) {
-      const newTatoe = tatoe.map((item) => {
-        if (item.tId === tId) {
-          return {
-            tId: item.tId,
-            title: item.title,
-            shortParaphrase: item.shortParaphrase,
-            description: item.description,
-            createdAt: item.createdAt,
-            updatedAt: item.updatedAt,
-          };
-        } else {
-          return item;
-        }
-      });
-      setTatoe(newTatoe);
+  // // const [tatoe, setTatoe] = useRecoilState<Tatoe[]>(TatoeAtom);
 
-      tatoe.map((item) => {
-        if (item.tId === tId) {
-          router.push({
-            pathname: '/DashBoard/UserTatoeList',
-          });
-        }
-      });
-    }
-    router.push({
-      pathname: '/DashBoard/UserTatoeList',
-    });
-  };
+  // const handleClickCancel = () => {
+  //   if (tId) {
+  //     const newTatoe = tatoe.map((item) => {
+  //       if (item.tId === tId) {
+  //         return {
+  //           tId: item.tId,
+  //           title: item.title,
+  //           shortParaphrase: item.shortParaphrase,
+  //           description: item.description,
+  //           createdAt: item.createdAt,
+  //           updatedAt: item.updatedAt,
+  //         };
+  //       } else {
+  //         return item;
+  //       }
+  //     });
+  //     setTatoe(newTatoe);
+
+  //     tatoe.map((item) => {
+  //       if (item.tId === tId) {
+  //         router.push({
+  //           pathname: '/DashBoard/UserTatoeList',
+  //         });
+  //       }
+  //     });
+  //   }
+  //   router.push({
+  //     pathname: '/DashBoard/UserTatoeList',
+  //   });
+  // };
 
   return (
     <form className='flex flex-col gap-6' onSubmit={onSubmit}>

--- a/src/components/DashBoard/Tatoe/TatoeForm.tsx
+++ b/src/components/DashBoard/Tatoe/TatoeForm.tsx
@@ -3,12 +3,15 @@ import React, {
   FormEventHandler,
   MouseEventHandler,
   SetStateAction,
+  useEffect,
+  useState,
 } from 'react';
 import { RegisterImageForExplanationTatoe } from '../../../pages/Register/RegisterTatoeChild/RegisterImageForExplanationTatoe';
 import { RegisterTatoeDescription } from '../../../pages/Register/RegisterTatoeChild/RegisterTatoeDescription';
 import { RegisterTatoeShortParaphrase } from '../../../pages/Register/RegisterTatoeChild/RegisterTatoeShortParaphrase';
 import { RegisterTatoeTitle } from '../../../pages/Register/RegisterTatoeChild/RegisterTatoeTitle';
 import { CancelTatoeBtn } from '../../btn/CancelTatoeBtn';
+import { CreateTatoeBtn } from '../../btn/CreateTatoeBtn';
 import { UpdateTatoeBtn } from '../../btn/UpdateTatoeBtn';
 import { Tatoe } from '../../types/types';
 
@@ -20,8 +23,8 @@ type TatoeFormProps = {
   setImageUrl: Dispatch<SetStateAction<string | null>>;
   defaultImageUrl: string | null;
   setDefaultImageUrl: Dispatch<SetStateAction<string | null>>;
-  deleteExplanationImage: MouseEventHandler<HTMLButtonElement>;
-  tatoe: Tatoe[];
+  deleteExplanationImage?: MouseEventHandler<HTMLButtonElement>;
+  tatoe?: Tatoe[];
 } & Tatoe;
 
 export const TatoeForm = ({
@@ -42,6 +45,14 @@ export const TatoeForm = ({
   createdAt,
   updatedAt,
 }: TatoeFormProps) => {
+  const [isUpdate, setIsUpdate] = useState<boolean>(false);
+  console.log(tId);
+  useEffect(() => {
+    if (tId) {
+      setIsUpdate(true);
+    }
+  }, [tId]);
+
   return (
     <form className='flex flex-col gap-6' onSubmit={onSubmit}>
       <RegisterTatoeTitle title={title} setTitle={setTitle} />
@@ -62,15 +73,19 @@ export const TatoeForm = ({
       />
       <div className='mx-auto md:mx-0 md:justify-end pt-6 flex flex-col smd:flex-row gap-6'>
         <CancelTatoeBtn tId={tId} />
-        <UpdateTatoeBtn
-          tatoe={tatoe}
-          tId={tId}
-          createdAt={createdAt}
-          updatedAt={updatedAt}
-          title={title}
-          shortParaphrase={shortParaphrase}
-          description={description}
-        />
+        {!isUpdate ? (
+          <CreateTatoeBtn />
+        ) : (
+          <UpdateTatoeBtn
+            tatoe={tatoe}
+            tId={tId}
+            createdAt={createdAt}
+            updatedAt={updatedAt}
+            title={title}
+            shortParaphrase={shortParaphrase}
+            description={description}
+          />
+        )}
       </div>
     </form>
   );

--- a/src/components/DashBoard/Tatoe/TatoeForm.tsx
+++ b/src/components/DashBoard/Tatoe/TatoeForm.tsx
@@ -1,0 +1,77 @@
+import React, {
+  Dispatch,
+  FormEventHandler,
+  MouseEventHandler,
+  SetStateAction,
+} from 'react';
+import { RegisterImageForExplanationTatoe } from '../../../pages/Register/RegisterTatoeChild/RegisterImageForExplanationTatoe';
+import { RegisterTatoeDescription } from '../../../pages/Register/RegisterTatoeChild/RegisterTatoeDescription';
+import { RegisterTatoeShortParaphrase } from '../../../pages/Register/RegisterTatoeChild/RegisterTatoeShortParaphrase';
+import { RegisterTatoeTitle } from '../../../pages/Register/RegisterTatoeChild/RegisterTatoeTitle';
+import { CancelTatoeBtn } from '../../btn/CancelTatoeBtn';
+import { UpdateTatoeBtn } from '../../btn/UpdateTatoeBtn';
+import { Tatoe } from '../../types/types';
+
+type TatoeFormProps = {
+  onSubmit: FormEventHandler<HTMLFormElement>;
+  setTitle: Dispatch<SetStateAction<string | null>>;
+  setShortParaphrase: Dispatch<SetStateAction<string | null>>;
+  setDescription: Dispatch<SetStateAction<string | null>>;
+  setImageUrl: Dispatch<SetStateAction<string | null>>;
+  defaultImageUrl: string | null;
+  setDefaultImageUrl: Dispatch<SetStateAction<string | null>>;
+  deleteExplanationImage: MouseEventHandler<HTMLButtonElement>;
+  tatoe: Tatoe[];
+} & Tatoe;
+
+export const TatoeForm = ({
+  onSubmit,
+  setTitle,
+  title,
+  shortParaphrase,
+  setShortParaphrase,
+  description,
+  setDescription,
+  imageUrl,
+  setImageUrl,
+  defaultImageUrl,
+  setDefaultImageUrl,
+  deleteExplanationImage,
+  tId,
+  tatoe,
+  createdAt,
+  updatedAt,
+}: TatoeFormProps) => {
+  return (
+    <form className='flex flex-col gap-6' onSubmit={onSubmit}>
+      <RegisterTatoeTitle title={title} setTitle={setTitle} />
+      <RegisterTatoeShortParaphrase
+        shortParaphrase={shortParaphrase}
+        setShortParaphrase={setShortParaphrase}
+      />
+      <RegisterTatoeDescription
+        description={description}
+        setDescription={setDescription}
+      />
+      <RegisterImageForExplanationTatoe
+        setImageUrl={setImageUrl}
+        imageUrl={imageUrl}
+        defaultImageUrl={defaultImageUrl}
+        setDefaultImageUrl={setDefaultImageUrl}
+        deleteExplanationImage={deleteExplanationImage}
+      />
+      <div className='mx-auto md:mx-0 md:justify-end pt-6 flex flex-col smd:flex-row gap-6'>
+        <CancelTatoeBtn tId={tId} />
+        <UpdateTatoeBtn
+          tatoe={tatoe}
+          tId={tId}
+          createdAt={createdAt}
+          updatedAt={updatedAt}
+          title={title}
+          shortParaphrase={shortParaphrase}
+          description={description}
+        />
+      </div>
+    </form>
+  );
+};

--- a/src/components/DashBoard/Tatoe/TatoeForm.tsx
+++ b/src/components/DashBoard/Tatoe/TatoeForm.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router';
 import React, {
   Dispatch,
   FormEventHandler,
@@ -10,10 +11,10 @@ import { RegisterImageForExplanationTatoe } from '../../../pages/Register/Regist
 import { RegisterTatoeDescription } from '../../../pages/Register/RegisterTatoeChild/RegisterTatoeDescription';
 import { RegisterTatoeShortParaphrase } from '../../../pages/Register/RegisterTatoeChild/RegisterTatoeShortParaphrase';
 import { RegisterTatoeTitle } from '../../../pages/Register/RegisterTatoeChild/RegisterTatoeTitle';
-import { CancelTatoeBtn } from '../../btn/CancelTatoeBtn';
-import { CreateTatoeBtn } from '../../btn/CreateTatoeBtn';
+// import { CancelTatoeBtn } from '../../btn/CancelTatoeBtn';
+// import { CreateTatoeBtn } from '../../btn/CreateTatoeBtn';
 import { RegisterTatoeBtn } from '../../btn/RegisterTatoeBtn';
-import { UpdateTatoeBtn } from '../../btn/UpdateTatoeBtn';
+// import { UpdateTatoeBtn } from '../../btn/UpdateTatoeBtn';
 import { Tatoe } from '../../types/types';
 
 type TatoeFormProps = {
@@ -109,9 +110,40 @@ export const TatoeForm = ({
         deleteExplanationImage={deleteExplanationImage}
       />
       <div className='mx-auto md:mx-0 md:justify-end pt-6 flex flex-col smd:flex-row gap-6'>
-        <RegisterTatoeBtn cancel />
-        <CancelTatoeBtn tId={tId} />
-        {!isUpdate ? (
+        <RegisterTatoeBtn
+          role='cancel'
+          btnName='キャンセル'
+          btnColor='white'
+          btnType='button'
+          tId={tId}
+          tatoe={tatoe}
+          onClickCancel={handleClickCancel}
+        />
+        {isUpdate ? (
+          <RegisterTatoeBtn
+            role='create'
+            btnColor='black'
+            btnName='投稿する'
+            btnType='submit'
+          />
+        ) : (
+          <RegisterTatoeBtn
+            role='update'
+            btnColor='black'
+            btnName='更新する'
+            btnType='submit'
+            tId={tId}
+            tatoe={tatoe}
+            createdAt={createdAt}
+            updatedAt={updatedAt}
+            title={title}
+            shortParaphrase={shortParaphrase}
+            description={description}
+          />
+        )}
+
+        {/* <CancelTatoeBtn tId={tId} /> */}
+        {/* {!isUpdate ? (
           <CreateTatoeBtn />
         ) : (
           <UpdateTatoeBtn
@@ -123,7 +155,7 @@ export const TatoeForm = ({
             shortParaphrase={shortParaphrase}
             description={description}
           />
-        )}
+        )} */}
       </div>
     </form>
   );

--- a/src/components/DashBoard/Tatoe/TatoeForm.tsx
+++ b/src/components/DashBoard/Tatoe/TatoeForm.tsx
@@ -12,6 +12,7 @@ import { RegisterTatoeShortParaphrase } from '../../../pages/Register/RegisterTa
 import { RegisterTatoeTitle } from '../../../pages/Register/RegisterTatoeChild/RegisterTatoeTitle';
 import { CancelTatoeBtn } from '../../btn/CancelTatoeBtn';
 import { CreateTatoeBtn } from '../../btn/CreateTatoeBtn';
+import { RegisterTatoeBtn } from '../../btn/RegisterTatoeBtn';
 import { UpdateTatoeBtn } from '../../btn/UpdateTatoeBtn';
 import { Tatoe } from '../../types/types';
 
@@ -53,6 +54,42 @@ export const TatoeForm = ({
     }
   }, [tId]);
 
+  // cancel btn あとでけす
+  const router = useRouter();
+
+  // const [tatoe, setTatoe] = useRecoilState<Tatoe[]>(TatoeAtom);
+
+  const handleClickCancel = () => {
+    if (tId) {
+      const newTatoe = tatoe.map((item) => {
+        if (item.tId === tId) {
+          return {
+            tId: item.tId,
+            title: item.title,
+            shortParaphrase: item.shortParaphrase,
+            description: item.description,
+            createdAt: item.createdAt,
+            updatedAt: item.updatedAt,
+          };
+        } else {
+          return item;
+        }
+      });
+      setTatoe(newTatoe);
+
+      tatoe.map((item) => {
+        if (item.tId === tId) {
+          router.push({
+            pathname: '/DashBoard/UserTatoeList',
+          });
+        }
+      });
+    }
+    router.push({
+      pathname: '/DashBoard/UserTatoeList',
+    });
+  };
+
   return (
     <form className='flex flex-col gap-6' onSubmit={onSubmit}>
       <RegisterTatoeTitle title={title} setTitle={setTitle} />
@@ -72,6 +109,7 @@ export const TatoeForm = ({
         deleteExplanationImage={deleteExplanationImage}
       />
       <div className='mx-auto md:mx-0 md:justify-end pt-6 flex flex-col smd:flex-row gap-6'>
+        <RegisterTatoeBtn cancel />
         <CancelTatoeBtn tId={tId} />
         {!isUpdate ? (
           <CreateTatoeBtn />

--- a/src/components/DashBoard/TatoeList.tsx
+++ b/src/components/DashBoard/TatoeList.tsx
@@ -18,7 +18,6 @@ export const TatoeList = (): JSX.Element => {
   const router = useRouter();
   const [tatoe, setTatoe] = useRecoilState<Tatoe[]>(TatoeAtom);
 
-  console.log('@TatoeList tatoe ++', tatoe);
   if (!userId) {
     return null;
   }
@@ -54,7 +53,7 @@ export const TatoeList = (): JSX.Element => {
                     sm:justify-between
                     group
                     '
-                key={item.tId}
+                key={item.tId as string}
               >
                 <li className='flex-grow'>
                   <ul

--- a/src/components/btn/CancelTatoeBtn.tsx
+++ b/src/components/btn/CancelTatoeBtn.tsx
@@ -5,15 +5,15 @@ import { TatoeAtom } from '../utils/atoms/TatoeAtom';
 import { Tatoe } from '../types/types';
 
 export const CancelTatoeBtn = (props: Tatoe) => {
-  const { query_tId } = props;
+  const { tId } = props;
   const router = useRouter();
 
   const [tatoe, setTatoe] = useRecoilState<Tatoe[]>(TatoeAtom);
 
   const handleClickCancel = () => {
-    if (query_tId) {
+    if (tId) {
       const newTatoe = tatoe.map((item) => {
-        if (item.tId === query_tId) {
+        if (item.tId === tId) {
           return {
             tId: item.tId,
             title: item.title,
@@ -29,7 +29,7 @@ export const CancelTatoeBtn = (props: Tatoe) => {
       setTatoe(newTatoe);
 
       tatoe.map((item) => {
-        if (item.tId === query_tId) {
+        if (item.tId === tId) {
           router.push({
             pathname: '/DashBoard/UserTatoeList',
           });

--- a/src/components/btn/CancelTatoeBtn.tsx
+++ b/src/components/btn/CancelTatoeBtn.tsx
@@ -4,69 +4,69 @@ import { useRecoilState } from 'recoil';
 import { TatoeAtom } from '../utils/atoms/TatoeAtom';
 import { Tatoe } from '../types/types';
 
-export const CancelTatoeBtn = (props: Tatoe) => {
-  const { tId } = props;
-  // const router = useRouter();
+// export const CancelTatoeBtn = (props: Tatoe) => {
+//   const { tId } = props;
+// const router = useRouter();
 
-  // const [tatoe, setTatoe] = useRecoilState<Tatoe[]>(TatoeAtom);
+// const [tatoe, setTatoe] = useRecoilState<Tatoe[]>(TatoeAtom);
 
-  // const handleClickCancel = () => {
-  //   if (tId) {
-  //     const newTatoe = tatoe.map((item) => {
-  //       if (item.tId === tId) {
-  //         return {
-  //           tId: item.tId,
-  //           title: item.title,
-  //           shortParaphrase: item.shortParaphrase,
-  //           description: item.description,
-  //           createdAt: item.createdAt,
-  //           updatedAt: item.updatedAt,
-  //         };
-  //       } else {
-  //         return item;
-  //       }
-  //     });
-  //     setTatoe(newTatoe);
+// const handleClickCancel = () => {
+//   if (tId) {
+//     const newTatoe = tatoe.map((item) => {
+//       if (item.tId === tId) {
+//         return {
+//           tId: item.tId,
+//           title: item.title,
+//           shortParaphrase: item.shortParaphrase,
+//           description: item.description,
+//           createdAt: item.createdAt,
+//           updatedAt: item.updatedAt,
+//         };
+//       } else {
+//         return item;
+//       }
+//     });
+//     setTatoe(newTatoe);
 
-  //     tatoe.map((item) => {
-  //       if (item.tId === tId) {
-  //         router.push({
-  //           pathname: '/DashBoard/UserTatoeList',
-  //         });
-  //       }
-  //     });
-  //   }
-  //   router.push({
-  //     pathname: '/DashBoard/UserTatoeList',
-  //   });
-  // };
+//     tatoe.map((item) => {
+//       if (item.tId === tId) {
+//         router.push({
+//           pathname: '/DashBoard/UserTatoeList',
+//         });
+//       }
+//     });
+//   }
+//   router.push({
+//     pathname: '/DashBoard/UserTatoeList',
+//   });
+// };
 
-  return (
-    <div className='flex justify-end group'>
-      <button
-        onClick={handleClickCancel}
-        type='button'
-        className='
-        btn-m-white
-      '
-      >
-        キャンセル
-      </button>
-      <div
-        className='
-      position
-      relative
-      '
-      >
-        <span
-          className='
-          absolute
-          material-symbols-outlined
-          btn-m-icon-black'
-        >
-          chevron_right
-        </span>
-      </div>
-    </div>
-  );
-};
+//   return (
+//     <div className='flex justify-end group'>
+//       <button
+//         onClick={handleClickCancel}
+//         type='button'
+//         className='
+//         btn-m-white
+//       '
+//       >
+//         キャンセル
+//       </button>
+//       <div
+//         className='
+//       position
+//       relative
+//       '
+//       >
+//         <span
+//           className='
+//           absolute
+//           material-symbols-outlined
+//           btn-m-icon-black'
+//         >
+//           chevron_right
+//         </span>
+//       </div>
+//     </div>
+//   );
+// };

--- a/src/components/btn/CancelTatoeBtn.tsx
+++ b/src/components/btn/CancelTatoeBtn.tsx
@@ -6,40 +6,40 @@ import { Tatoe } from '../types/types';
 
 export const CancelTatoeBtn = (props: Tatoe) => {
   const { tId } = props;
-  const router = useRouter();
+  // const router = useRouter();
 
-  const [tatoe, setTatoe] = useRecoilState<Tatoe[]>(TatoeAtom);
+  // const [tatoe, setTatoe] = useRecoilState<Tatoe[]>(TatoeAtom);
 
-  const handleClickCancel = () => {
-    if (tId) {
-      const newTatoe = tatoe.map((item) => {
-        if (item.tId === tId) {
-          return {
-            tId: item.tId,
-            title: item.title,
-            shortParaphrase: item.shortParaphrase,
-            description: item.description,
-            createdAt: item.createdAt,
-            updatedAt: item.updatedAt,
-          };
-        } else {
-          return item;
-        }
-      });
-      setTatoe(newTatoe);
+  // const handleClickCancel = () => {
+  //   if (tId) {
+  //     const newTatoe = tatoe.map((item) => {
+  //       if (item.tId === tId) {
+  //         return {
+  //           tId: item.tId,
+  //           title: item.title,
+  //           shortParaphrase: item.shortParaphrase,
+  //           description: item.description,
+  //           createdAt: item.createdAt,
+  //           updatedAt: item.updatedAt,
+  //         };
+  //       } else {
+  //         return item;
+  //       }
+  //     });
+  //     setTatoe(newTatoe);
 
-      tatoe.map((item) => {
-        if (item.tId === tId) {
-          router.push({
-            pathname: '/DashBoard/UserTatoeList',
-          });
-        }
-      });
-    }
-    router.push({
-      pathname: '/DashBoard/UserTatoeList',
-    });
-  };
+  //     tatoe.map((item) => {
+  //       if (item.tId === tId) {
+  //         router.push({
+  //           pathname: '/DashBoard/UserTatoeList',
+  //         });
+  //       }
+  //     });
+  //   }
+  //   router.push({
+  //     pathname: '/DashBoard/UserTatoeList',
+  //   });
+  // };
 
   return (
     <div className='flex justify-end group'>

--- a/src/components/btn/CreateTatoeBtn.tsx
+++ b/src/components/btn/CreateTatoeBtn.tsx
@@ -1,20 +1,5 @@
-import { useEffect, useState } from 'react';
-import { TatoeBtnProps } from '../types/types';
-
-export const CreateTatoeBtn = (props: TatoeBtnProps) => {
-  const { query_tId } = props;
-  const [isUpdate, setIsUpdate] = useState(false);
-
-  useEffect(() => {
-    const btnStyle = () => {
-      if (query_tId) {
-        setIsUpdate(true);
-      }
-    };
-    btnStyle();
-  }, [query_tId]);
-
-  return isUpdate ? null : (
+export const CreateTatoeBtn = () => {
+  return (
     <div className='flex justify-end group'>
       <button
         type='submit'

--- a/src/components/btn/RegisterTatoeBtn.tsx
+++ b/src/components/btn/RegisterTatoeBtn.tsx
@@ -15,58 +15,41 @@ const btnType = {
 
 type BtnCommonProps = {
   btnName: Required<string>;
-  type: Required<BtnType>;
-  btnColor: BtnColor;
+  btnType: Required<BtnType>;
+  btnColor: Required<BtnColor>;
 };
 
 type BtnType = keyof typeof btnType;
 
-type UpdateTatoeBtnProps = {
-  // btnName: Required<string>;
-  // type: Required<BtnType>;
-  // btnColor: BtnColor;
-  tId?: string;
-  tatoe?: Tatoe[];
-  createdAt?: string;
-  updatedAt?: string;
-  title?: string;
-  shortParaphrase?: string;
-  description?: string;
-};
-
-type CancelTatoeBtnProps = {
-  // btnName: Required<string>;
-  // type: Required<BtnType>;
-  // btnColor: BtnColor;
-  tId?: string;
-  tatoe?: Tatoe[];
-  onClickCancel?: () => void;
-};
-
 type Props =
-  | { common?: BtnCommonProps; create?: null; update?: never; cancel?: never }
+  | { role: 'create'; onClickCancel?: never }
   | {
-      common?: BtnCommonProps;
-      create?: never;
-      update?: BtnCommonProps & UpdateTatoeBtnProps;
-      cancel?: never;
+      role: 'update';
+      tId: string[] | string;
+      tatoe: Tatoe[];
+      createdAt: string;
+      updatedAt: string;
+      title: string | null;
+      shortParaphrase: string | null;
+      description: string | null;
+      onClickCancel?: never;
     }
   | {
-      common?: BtnCommonProps;
-      create?: never;
-      update?: never;
-      cancel?: BtnCommonProps & CancelTatoeBtnProps;
+      role: 'cancel';
+      tId: string | string[];
+      tatoe: Tatoe[];
+      onClickCancel: () => void;
     };
 
-export const RegisterTatoeBtn = ({ cancel, common, create, update }: Props) => {
+export const RegisterTatoeBtn = (props: Required<BtnCommonProps> & Props) => {
   return (
     <div className='flex justify-end group'>
       <button
         type='submit'
-        className={`btn-m-color ${common ? common.btnColor : null}`}
-        onClick={cancel ? cancel.onClickCancel : null}
+        className={`btn-m-color ${props.btnColor}`}
+        onClick={props.onClickCancel ? props?.onClickCancel : null}
       >
-        {common ? common.btnName : null}
+        {props.btnName}
       </button>
       <div
         className='

--- a/src/components/btn/RegisterTatoeBtn.tsx
+++ b/src/components/btn/RegisterTatoeBtn.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { Tatoe } from '../types/types';
+
+const btnColor = {
+  black: 'bg-black text-white',
+  white: 'bg-white text-black',
+} as const;
+
+type BtnColor = keyof typeof btnColor;
+
+const btnType = {
+  submit: 'submit',
+  button: 'button',
+};
+
+type BtnCommonProps = {
+  btnName: Required<string>;
+  type: Required<BtnType>;
+  btnColor: BtnColor;
+};
+
+type BtnType = keyof typeof btnType;
+
+type UpdateTatoeBtnProps = {
+  // btnName: Required<string>;
+  // type: Required<BtnType>;
+  // btnColor: BtnColor;
+  tId?: string;
+  tatoe?: Tatoe[];
+  createdAt?: string;
+  updatedAt?: string;
+  title?: string;
+  shortParaphrase?: string;
+  description?: string;
+};
+
+type CancelTatoeBtnProps = {
+  // btnName: Required<string>;
+  // type: Required<BtnType>;
+  // btnColor: BtnColor;
+  tId?: string;
+  tatoe?: Tatoe[];
+  onClickCancel?: () => void;
+};
+
+type Props =
+  | { common?: BtnCommonProps; create?: null; update?: never; cancel?: never }
+  | {
+      common?: BtnCommonProps;
+      create?: never;
+      update?: BtnCommonProps & UpdateTatoeBtnProps;
+      cancel?: never;
+    }
+  | {
+      common?: BtnCommonProps;
+      create?: never;
+      update?: never;
+      cancel?: BtnCommonProps & CancelTatoeBtnProps;
+    };
+
+export const RegisterTatoeBtn = ({ cancel, common, create, update }: Props) => {
+  return (
+    <div className='flex justify-end group'>
+      <button
+        type='submit'
+        className={`btn-m-color ${common ? common.btnColor : null}`}
+        onClick={cancel ? cancel.onClickCancel : null}
+      >
+        {common ? common.btnName : null}
+      </button>
+      <div
+        className='
+  position
+  relative
+  '
+      >
+        <span
+          className='
+      absolute
+      material-symbols-outlined
+      btn-m-icon-white
+      '
+        >
+          chevron_right
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/src/components/btn/RegisterTatoeBtn.tsx
+++ b/src/components/btn/RegisterTatoeBtn.tsx
@@ -2,11 +2,16 @@ import React from 'react';
 import { Tatoe } from '../types/types';
 
 const btnColor = {
-  black: 'bg-black text-white',
-  white: 'bg-white text-black',
+  create: 'bg-black text-white',
+  update: 'bg-black text-white',
+  cancel: 'bg-white text-black border-gray-800 border',
 } as const;
 
-type BtnColor = keyof typeof btnColor;
+const btnIcon = {
+  create: 'text-white',
+  update: 'text-white',
+  cancel: 'text-black',
+} as const;
 
 const btnType = {
   submit: 'submit',
@@ -16,15 +21,14 @@ const btnType = {
 type BtnCommonProps = {
   btnName: Required<string>;
   btnType: Required<BtnType>;
-  btnColor: Required<BtnColor>;
 };
 
 type BtnType = keyof typeof btnType;
 
 type Props =
-  | { role: 'create'; onClickCancel?: never }
+  | { variant: 'create'; onClickCancel?: never }
   | {
-      role: 'update';
+      variant: 'update';
       tId: string[] | string;
       tatoe: Tatoe[];
       createdAt: string;
@@ -35,7 +39,7 @@ type Props =
       onClickCancel?: never;
     }
   | {
-      role: 'cancel';
+      variant: 'cancel';
       tId: string | string[];
       tatoe: Tatoe[];
       onClickCancel: () => void;
@@ -46,7 +50,7 @@ export const RegisterTatoeBtn = (props: Required<BtnCommonProps> & Props) => {
     <div className='flex justify-end group'>
       <button
         type='submit'
-        className={`btn-m-color ${props.btnColor}`}
+        className={`btn-m-color ${btnColor[props.variant]}`}
         onClick={props.onClickCancel ? props?.onClickCancel : null}
       >
         {props.btnName}
@@ -58,11 +62,9 @@ export const RegisterTatoeBtn = (props: Required<BtnCommonProps> & Props) => {
   '
       >
         <span
-          className='
-      absolute
-      material-symbols-outlined
-      btn-m-icon-white
-      '
+          className={`absolute
+          material-symbols-outlined
+          btn-m-icon-base ${btnIcon[props.variant]}`}
         >
           chevron_right
         </span>

--- a/src/components/btn/UpdateTatoeBtn.tsx
+++ b/src/components/btn/UpdateTatoeBtn.tsx
@@ -2,18 +2,18 @@ import React, { useEffect, useState } from 'react';
 import { TatoeBtnProps } from '../types/types';
 
 export const UpdateTatoeBtn = (props: TatoeBtnProps) => {
-  const { query_tId } = props;
+  const { tId } = props;
 
   const [isUpdate, setIsUpdate] = useState(false);
 
   useEffect(() => {
     const btnStyle = () => {
-      if (query_tId) {
+      if (tId) {
         setIsUpdate(true);
       }
     };
     btnStyle();
-  }, [query_tId]);
+  }, [tId]);
 
   return isUpdate ? (
     <div className='flex justify-end group'>

--- a/src/components/hooks/handleMoveToEdit.tsx
+++ b/src/components/hooks/handleMoveToEdit.tsx
@@ -1,27 +1,10 @@
 import { useRouter } from 'next/router';
 import { Tatoe } from '../types/types';
 
-export const useHandleMoveToEdit = ({
-  tId,
-  title,
-  shortParaphrase,
-  description,
-  imageId,
-  imageUrl,
-}: Tatoe) => {
+export const useHandleMoveToEdit = ({ tId }: Tatoe) => {
   const router = useRouter();
   const handleMoveToEdit = () => {
-    router.push({
-      pathname: '/Register/',
-      query: {
-        tId,
-        //   // title,
-        //   // shortParaphrase,
-        //   // description,
-        //   // imageId,
-        //   // imageUrl,
-      },
-    });
+    router.push(`/Register/${tId}`);
   };
   return { handleMoveToEdit };
 };

--- a/src/components/hooks/useTatoe.tsx
+++ b/src/components/hooks/useTatoe.tsx
@@ -4,7 +4,7 @@ import { TatoeAtom } from '../utils/atoms/TatoeAtom';
 import { useApi } from './useApi';
 
 export const useTatoe = (props: TatoeBtnHooksProps) => {
-  const { tId, userId, query_tId } = props;
+  const { tId, userId } = props;
   const [tatoe, setTatoe] = useRecoilState(TatoeAtom);
 
   const { api: postTatoeApi } = useApi('/tatoe', { method: 'POST' });
@@ -74,7 +74,7 @@ export const useTatoe = (props: TatoeBtnHooksProps) => {
     const { data } = await putTatoeApi(value.formData);
 
     const updatedTatoe = tatoe.map((item: Tatoe) => {
-      if (item.tId === query_tId) {
+      if (item.tId === tId) {
         return {
           tId: item.tId,
           userId: data.userId,

--- a/src/components/hooks/useTatoeCancel.tsx
+++ b/src/components/hooks/useTatoeCancel.tsx
@@ -1,0 +1,45 @@
+import { useRouter } from 'next/router';
+import { SetterOrUpdater } from 'recoil';
+import { Tatoe } from '../types/types';
+
+type CancelProps = {
+  tId?: string | string[];
+  tatoe?: Tatoe[];
+  setTatoe?: SetterOrUpdater<Tatoe[]>;
+};
+
+export const useTatoeCancel = ({ tId, tatoe, setTatoe }: CancelProps) => {
+  const router = useRouter();
+
+  const handleClickCancel = () => {
+    if (tId) {
+      const newTatoe = tatoe.map((item) => {
+        if (item.tId === tId) {
+          return {
+            tId: item.tId,
+            title: item.title,
+            shortParaphrase: item.shortParaphrase,
+            description: item.description,
+            createdAt: item.createdAt,
+            updatedAt: item.updatedAt,
+          };
+        } else {
+          return item;
+        }
+      });
+      setTatoe(newTatoe);
+
+      tatoe.map((item) => {
+        if (item.tId === tId) {
+          router.push({
+            pathname: '/DashBoard/UserTatoeList',
+          });
+        }
+      });
+    }
+    router.push({
+      pathname: '/DashBoard/UserTatoeList',
+    });
+  };
+  return { handleClickCancel };
+};

--- a/src/components/types/mouseEvent.ts
+++ b/src/components/types/mouseEvent.ts
@@ -1,9 +1,0 @@
-export type MouseEventProps = {
-  onClick: (e: React.MouseEvent<HTMLInputElement>) => void;
-  onChange: (e: React.ChangeEvent<HTMLInputElement> | undefined) => void;
-  onkeypress: (e: React.KeyboardEvent<HTMLInputElement>) => void;
-  onBlur: (e: React.FocusEvent<HTMLInputElement>) => void;
-  onFocus: (e: React.FocusEvent<HTMLInputElement>) => void;
-  onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
-  onClickDiv: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
-};

--- a/src/components/types/types.tsx
+++ b/src/components/types/types.tsx
@@ -4,7 +4,7 @@ import { ReactNode } from 'react';
 import { SetterOrUpdater } from 'recoil';
 
 export type Tatoe = {
-  tId?: string;
+  tId?: string | string[];
   userId?: string;
   title?: string;
   shortParaphrase?: string;
@@ -13,7 +13,6 @@ export type Tatoe = {
   updatedAt?: string;
   imageUrl?: string;
   imageId?: string;
-  query_tId?: string | string[];
   formData?: FormData;
 };
 
@@ -27,7 +26,6 @@ export type AllUserTatoe = {
   updatedAt?: string;
   imageUrl?: string;
   imageId?: string;
-  query_tId?: string | string[];
   formData?: FormData;
   userName: string;
 };
@@ -73,7 +71,6 @@ export type WithoutPropsChildrenLayouts = {
 };
 
 export type TatoeBtnProps = {
-  // onClick: () => void;
   tatoe?: Tatoe[];
 } & Tatoe;
 

--- a/src/pages/Register/CreateTatoePage.tsx
+++ b/src/pages/Register/CreateTatoePage.tsx
@@ -1,0 +1,98 @@
+import React, { FormEventHandler, useState } from 'react';
+import { CreateTatoeBtn } from '../../components/btn/CreateTatoeBtn';
+import { RegisterTatoeTitle } from './RegisterTatoeChild/RegisterTatoeTitle';
+import { RegisterTatoeShortParaphrase } from './RegisterTatoeChild/RegisterTatoeShortParaphrase';
+import { RegisterTatoeDescription } from './RegisterTatoeChild/RegisterTatoeDescription';
+
+import { CancelTatoeBtn } from '../../components/btn/CancelTatoeBtn';
+import { useRouter } from 'next/router';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { TatoeAtom } from '../../components/utils/atoms/TatoeAtom';
+import { LoginUserAtom } from '../../components/utils/atoms/LoginUserAtom';
+import { useAuth } from '../../components/hooks/useAuth';
+import { useUserInfo } from '../../components/hooks/useUserInfo';
+import { useTatoe } from '../../components/hooks/useTatoe';
+import { useAlert } from '../../components/hooks/useAlert';
+import { RegisterImageForExplanationTatoe } from './RegisterTatoeChild/RegisterImageForExplanationTatoe';
+
+export const CreateTatoePage = () => {
+  const router = useRouter();
+
+  const [title, setTitle] = useState<string | null>('');
+  const [shortParaphrase, setShortParaphrase] = useState<string | null>('');
+  const [description, setDescription] = useState<string | null>('');
+  const [createdAt, setCreatedAt] = useState<string | null>('');
+  const [updatedAt, setUpdatedAt] = useState<string | null>('');
+
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [defaultImageUrl, setDefaultImageUrl] = useState<string | null>(null);
+
+  const [tatoe, setTatoe] = useRecoilState(TatoeAtom);
+  const persistAccessToken = useRecoilValue(LoginUserAtom);
+  const { userId } = useAuth();
+  const { user } = useUserInfo(userId);
+
+  const { createTatoe } = useTatoe({
+    tId: null,
+    router: null,
+    tatoe,
+    user,
+    setTatoe,
+    persistAccessToken,
+    userId,
+    title,
+    shortParaphrase,
+    description,
+    createdAt,
+    updatedAt,
+  });
+
+  const handleOnSubmit: FormEventHandler<HTMLFormElement> = async (e) => {
+    e.preventDefault();
+
+    const { alertRegisterTatoe, noInputsData } = useAlert({
+      userId,
+      user,
+      title,
+      shortParaphrase,
+      description,
+    });
+    if (noInputsData) {
+      alertRegisterTatoe();
+      return;
+    }
+    const formData = new FormData(e.currentTarget);
+
+    await createTatoe({
+      formData,
+    });
+
+    router.push({
+      pathname: '/DashBoard/UserTatoeList',
+    });
+  };
+
+  return (
+    <form className='flex flex-col gap-6' onSubmit={handleOnSubmit}>
+      <RegisterTatoeTitle title={title} setTitle={setTitle} />
+      <RegisterTatoeShortParaphrase
+        shortParaphrase={shortParaphrase}
+        setShortParaphrase={setShortParaphrase}
+      />
+      <RegisterTatoeDescription
+        description={description}
+        setDescription={setDescription}
+      />
+      <RegisterImageForExplanationTatoe
+        setImageUrl={setImageUrl}
+        imageUrl={imageUrl}
+        defaultImageUrl={defaultImageUrl}
+        setDefaultImageUrl={setDefaultImageUrl}
+      />
+      <div className='mx-auto md:mx-0 md:justify-end pt-6 flex flex-col smd:flex-row gap-6'>
+        <CancelTatoeBtn />
+        <CreateTatoeBtn />
+      </div>
+    </form>
+  );
+};

--- a/src/pages/Register/CreateTatoePage.tsx
+++ b/src/pages/Register/CreateTatoePage.tsx
@@ -1,10 +1,5 @@
 import React, { FormEventHandler, useState } from 'react';
-import { CreateTatoeBtn } from '../../components/btn/CreateTatoeBtn';
-import { RegisterTatoeTitle } from './RegisterTatoeChild/RegisterTatoeTitle';
-import { RegisterTatoeShortParaphrase } from './RegisterTatoeChild/RegisterTatoeShortParaphrase';
-import { RegisterTatoeDescription } from './RegisterTatoeChild/RegisterTatoeDescription';
 
-import { CancelTatoeBtn } from '../../components/btn/CancelTatoeBtn';
 import { useRouter } from 'next/router';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { TatoeAtom } from '../../components/utils/atoms/TatoeAtom';
@@ -13,7 +8,8 @@ import { useAuth } from '../../components/hooks/useAuth';
 import { useUserInfo } from '../../components/hooks/useUserInfo';
 import { useTatoe } from '../../components/hooks/useTatoe';
 import { useAlert } from '../../components/hooks/useAlert';
-import { RegisterImageForExplanationTatoe } from './RegisterTatoeChild/RegisterImageForExplanationTatoe';
+
+import { TatoeForm } from '../../components/DashBoard/Tatoe/TatoeForm';
 
 export const CreateTatoePage = () => {
   const router = useRouter();
@@ -73,26 +69,18 @@ export const CreateTatoePage = () => {
   };
 
   return (
-    <form className='flex flex-col gap-6' onSubmit={handleOnSubmit}>
-      <RegisterTatoeTitle title={title} setTitle={setTitle} />
-      <RegisterTatoeShortParaphrase
-        shortParaphrase={shortParaphrase}
-        setShortParaphrase={setShortParaphrase}
-      />
-      <RegisterTatoeDescription
-        description={description}
-        setDescription={setDescription}
-      />
-      <RegisterImageForExplanationTatoe
-        setImageUrl={setImageUrl}
-        imageUrl={imageUrl}
-        defaultImageUrl={defaultImageUrl}
-        setDefaultImageUrl={setDefaultImageUrl}
-      />
-      <div className='mx-auto md:mx-0 md:justify-end pt-6 flex flex-col smd:flex-row gap-6'>
-        <CancelTatoeBtn />
-        <CreateTatoeBtn />
-      </div>
-    </form>
+    <TatoeForm
+      onSubmit={handleOnSubmit}
+      title={title}
+      setTitle={setTitle}
+      shortParaphrase={shortParaphrase}
+      setShortParaphrase={setShortParaphrase}
+      description={description}
+      setDescription={setDescription}
+      imageUrl={imageUrl}
+      setImageUrl={setImageUrl}
+      defaultImageUrl={defaultImageUrl}
+      setDefaultImageUrl={setDefaultImageUrl}
+    />
   );
 };

--- a/src/pages/Register/RegisterTatoeChild/RegisterImageForExplanationTatoe.tsx
+++ b/src/pages/Register/RegisterTatoeChild/RegisterImageForExplanationTatoe.tsx
@@ -7,12 +7,11 @@ import React, {
 } from 'react';
 
 export type SubmitImageProps = {
-  query_tId?: string | string[];
   imageUrl?: string;
   setImageUrl: React.Dispatch<React.SetStateAction<string>>;
   defaultImageUrl?: string;
   setDefaultImageUrl: React.Dispatch<React.SetStateAction<string>>;
-  deleteExplanationImage: MouseEventHandler<HTMLButtonElement>;
+  deleteExplanationImage?: MouseEventHandler<HTMLButtonElement>;
 };
 
 export const RegisterImageForExplanationTatoe = ({

--- a/src/pages/Register/RegisterTatoeChild/RegisterTatoeShortParaphrase.tsx
+++ b/src/pages/Register/RegisterTatoeChild/RegisterTatoeShortParaphrase.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 type ShortParaphraseProps = {
-  query_tId?: string | string[];
   shortParaphrase: string | null;
   setShortParaphrase: React.Dispatch<
     React.SetStateAction<string | string[] | null>

--- a/src/pages/Register/UpdateTatoePage.tsx
+++ b/src/pages/Register/UpdateTatoePage.tsx
@@ -129,6 +129,7 @@ export const UpdateTatoePage = ({ tId, onCreateTatoe }: UpdateTatoePage) => {
       deleteExplanationImage={handleDeleteExplanationImage}
       tId={tId}
       tatoe={tatoe}
+      setTatoe={setTatoe}
       createdAt={createdAt}
       updatedAt={updatedAt}
     />

--- a/src/pages/Register/UpdateTatoePage.tsx
+++ b/src/pages/Register/UpdateTatoePage.tsx
@@ -5,8 +5,7 @@ import React, {
   useState,
 } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
-import { CancelTatoeBtn } from '../../components/btn/CancelTatoeBtn';
-import { UpdateTatoeBtn } from '../../components/btn/UpdateTatoeBtn';
+import { TatoeForm } from '../../components/DashBoard/Tatoe/TatoeForm';
 import { useAlert } from '../../components/hooks/useAlert';
 import { useApi } from '../../components/hooks/useApi';
 import { useAuth } from '../../components/hooks/useAuth';
@@ -15,10 +14,6 @@ import { useUserInfo } from '../../components/hooks/useUserInfo';
 import { Tatoe } from '../../components/types/types';
 import { LoginUserAtom } from '../../components/utils/atoms/LoginUserAtom';
 import { TatoeAtom } from '../../components/utils/atoms/TatoeAtom';
-import { RegisterImageForExplanationTatoe } from './RegisterTatoeChild/RegisterImageForExplanationTatoe';
-import { RegisterTatoeDescription } from './RegisterTatoeChild/RegisterTatoeDescription';
-import { RegisterTatoeShortParaphrase } from './RegisterTatoeChild/RegisterTatoeShortParaphrase';
-import { RegisterTatoeTitle } from './RegisterTatoeChild/RegisterTatoeTitle';
 
 export type UpdateTatoePage = {
   tId: string | string[];
@@ -119,35 +114,23 @@ export const UpdateTatoePage = ({ tId, onCreateTatoe }: UpdateTatoePage) => {
   };
 
   return (
-    <form className='flex flex-col gap-6' onSubmit={handleOnSubmit}>
-      <RegisterTatoeTitle title={title} setTitle={setTitle} />
-      <RegisterTatoeShortParaphrase
-        shortParaphrase={shortParaphrase}
-        setShortParaphrase={setShortParaphrase}
-      />
-      <RegisterTatoeDescription
-        description={description}
-        setDescription={setDescription}
-      />
-      <RegisterImageForExplanationTatoe
-        setImageUrl={setImageUrl}
-        imageUrl={imageUrl}
-        defaultImageUrl={defaultImageUrl}
-        setDefaultImageUrl={setDefaultImageUrl}
-        deleteExplanationImage={handleDeleteExplanationImage}
-      />
-      <div className='mx-auto md:mx-0 md:justify-end pt-6 flex flex-col smd:flex-row gap-6'>
-        <CancelTatoeBtn tId={tId} />
-        <UpdateTatoeBtn
-          tatoe={tatoe}
-          tId={tId}
-          createdAt={createdAt}
-          updatedAt={updatedAt}
-          title={title}
-          shortParaphrase={shortParaphrase}
-          description={description}
-        />
-      </div>
-    </form>
+    <TatoeForm
+      onSubmit={handleOnSubmit}
+      title={title}
+      setTitle={setTitle}
+      shortParaphrase={shortParaphrase}
+      setShortParaphrase={setShortParaphrase}
+      description={description}
+      setDescription={setDescription}
+      imageUrl={imageUrl}
+      setImageUrl={setImageUrl}
+      defaultImageUrl={defaultImageUrl}
+      setDefaultImageUrl={setDefaultImageUrl}
+      deleteExplanationImage={handleDeleteExplanationImage}
+      tId={tId}
+      tatoe={tatoe}
+      createdAt={createdAt}
+      updatedAt={updatedAt}
+    />
   );
 };

--- a/src/pages/Register/[tId]/index.tsx
+++ b/src/pages/Register/[tId]/index.tsx
@@ -1,7 +1,52 @@
-import React from 'react'
+import React from 'react';
+import Head from 'next/head';
+import 'tailwindcss/tailwind.css';
+import { Header } from '../../../components/Header/Header';
+import { RegisterTatoeHeadline } from '../RegisterTatoeHeadline';
+import { UpdateTatoePage } from '../UpdateTatoePage';
+import { useRouter } from 'next/router';
 
-export const index = () => {
+export default function Register() {
+  const router = useRouter();
+
+  const tId: string | string[] = router.query.tId;
+
+  const handleCreateTatoe = async () => {
+    router.push({
+      pathname: '/DashBoard/UserTatoeList',
+    });
+  };
   return (
-    <div>index</div>
-  )
+    <>
+      <Head>
+        <title>Tatoeba 例え話 登録ページ</title>
+        <link rel='favicon.ico' />
+      </Head>
+      <Header />
+      <section
+        className='
+          md:pt-[100px]
+          pt-[80px]
+          px-7
+          md:px-18
+          mx-auto
+          mb-12
+          '
+      >
+        <div
+          className='
+              frame-large
+              mx-auto
+              max-w-[1000px]
+              '
+        >
+          <RegisterTatoeHeadline />
+
+          {tId && (
+            <UpdateTatoePage tId={tId} onCreateTatoe={handleCreateTatoe} />
+          )}
+        </div>
+      </section>
+    </>
+  );
 }

--- a/src/pages/Register/index.tsx
+++ b/src/pages/Register/index.tsx
@@ -3,8 +3,7 @@ import Head from 'next/head';
 import 'tailwindcss/tailwind.css';
 import { Header } from '../../components/Header/Header';
 import { RegisterTatoeHeadline } from './RegisterTatoeHeadline';
-import { RegisterTatoeParent } from './RegisterTatoeParent';
-import { useRouter } from 'next/router';
+import { CreateTatoePage } from './CreateTatoePage';
 
 export default function Register() {
   return (
@@ -32,7 +31,7 @@ export default function Register() {
               '
         >
           <RegisterTatoeHeadline />
-          <RegisterTatoeParent />
+          <CreateTatoePage />
         </div>
       </section>
     </>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -60,7 +60,7 @@ text-xs transition-all group-hover:opacity-60;
 }
 
 .btn-m-color {
-  @apply p-4 w-[200px] rounded-full text-white text-xs transition-all bg-black group-hover:bg-opacity-80;
+  @apply p-4 w-[200px] rounded-full text-xs transition-all  group-hover:bg-opacity-80;
 }
 
 .btn-m-icon-base {
@@ -68,7 +68,7 @@ text-xs transition-all group-hover:opacity-60;
 }
 
 .btn-m-icon-white {
-  @apply btn-m-icon-base text-white;
+  @apply btn-m-icon-base;
 }
 
 .btn-m-icon-black {


### PR DESCRIPTION
# Issue URL

#90 

# このPRの対応範囲

#90 のとおり実装する。

# 変更理由・変更内容

- 以前は例え一覧の一つのリストをクリックすると、その値がuseRouterの router.queryを経由して値を渡したり、router.query自体がURLになっていたが、それだとあまり[SEO上よくないため](https://www.willgate.co.jp/promonista/url-parameter/#:~:text=%E3%83%91%E3%83%A9%E3%83%A1%E3%83%BC%E3%82%BF%E4%BB%98%E3%81%8D%E3%81%AE,%E8%AA%8D%E8%AD%98%E3%81%97%E3%81%BE%E3%81%99%E3%80%82)リファクタした。
- 以前は例えのCRUDの部分が RegisterTatoeParent.tsx に集中していたが、それだと依存関係と役割が多すぎるので例えの作成と更新のページに分けた。
- 更新のページはダイナミックルーティングを使用し例えごとに振り分けをしている。